### PR TITLE
feat: expand backend domain skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Node
+node_modules/
+frontend/node_modules/
+frontend/dist/
+
+# Java
+backend/target/
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# bobmta
+# BOB MTA Maintain Assistants 平台 - 阶段二后端框架
+
+该仓库用于逐步实现《BOB MTA（Maintain Assistants）综合运维平台 详细设计说明书》中的平台。本次迭代聚焦第二阶段目标：建立后端核心框架与领域模块雏形，提供统一响应格式、认证鉴权骨架以及符合详细设计的关键 API 草稿数据。
+
+## 项目结构
+
+```
+backend/   # Spring Boot 3 后端服务，提供 REST API
+frontend/  # React + Vite 前端单页应用
+```
+
+## 快速开始
+
+### 后端
+
+```bash
+cd backend
+mvn spring-boot:run
+```
+
+服务启动后可访问下列示例接口：
+
+| 接口 | 描述 | 备注 |
+| --- | --- | --- |
+| `POST /api/v1/auth/login` | 账号登录（内存账户） | 账号：`admin` / `admin123`、`operator` / `operator123` |
+| `GET /api/v1/auth/me` | 获取当前登录用户信息 | 需在 `Authorization: Bearer <token>` 头中携带登录返回的 token |
+| `GET /api/v1/customers` | 客户列表（分页 + 关键字/地区过滤） | 返回示例数据，结构贴合详细设计中的字段规划 |
+| `GET /api/v1/customers/{id}` | 客户详情视图 | 演示自定义字段分组、标签等信息 |
+| `GET /api/v1/plans` | 运维计划列表 | 支持按客户、状态筛选，返回计划进度摘要 |
+| `GET /api/v1/plans/{id}` | 运维计划详情 | 含节点执行模式需要的结构化数据 |
+| `GET /api/ping` | 健康检查 | 便于部署级联路由验证 |
+
+### 前端
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+开发服务器默认运行在 `http://localhost:5173`，页面会自动请求后端 `GET /api/ping` 接口并展示结果。
+
+> 说明：由于运行环境可能无法直接访问 npm 官方源，如遇安装失败，可配置镜像源（例如 `npm config set registry https://registry.npmmirror.com`）。
+
+## 下一步计划
+
+- 将当前内存实现替换为基于 PostgreSQL + MyBatis 的持久化访问层，并补充数据库建模脚本。
+- 引入多租户、模板中心、文件服务、审计日志等模块的领域骨架，实现跨模块协作接口。
+- 与前端协同定义 OpenAPI/接口契约，扩展前端状态管理以对接新增 API。
+- 补充单元测试与集成测试，构建覆盖率>80%的质量保障体系，并接入 CI。

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,89 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.bob.mta</groupId>
+    <artifactId>backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>bob-mta-backend</name>
+    <description>BOB MTA maintain assistants backend</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+            <version>3.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>aliyun-public</id>
+            <url>https://maven.aliyun.com/repository/public</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>aliyun-public</id>
+            <url>https://maven.aliyun.com/repository/public</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/backend/src/main/java/com/bob/mta/BobMtaApplication.java
+++ b/backend/src/main/java/com/bob/mta/BobMtaApplication.java
@@ -1,0 +1,14 @@
+package com.bob.mta;
+
+import com.bob.mta.common.security.JwtProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
+public class BobMtaApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BobMtaApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/api/PingController.java
+++ b/backend/src/main/java/com/bob/mta/api/PingController.java
@@ -1,0 +1,18 @@
+package com.bob.mta.api;
+
+import com.bob.mta.common.api.ApiResponse;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api", produces = MediaType.APPLICATION_JSON_VALUE)
+public class PingController {
+
+    @GetMapping("/ping")
+    public ApiResponse<Map<String, String>> ping() {
+        return ApiResponse.success(Map.of("status", "ok"));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/api/ApiResponse.java
+++ b/backend/src/main/java/com/bob/mta/common/api/ApiResponse.java
@@ -1,0 +1,63 @@
+package com.bob.mta.common.api;
+
+import com.bob.mta.common.exception.ErrorCode;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Generic wrapper for REST responses to enforce a consistent envelope structure.
+ *
+ * @param <T> payload type wrapped by the response
+ */
+public class ApiResponse<T> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final int code;
+
+    private final String message;
+
+    private final T data;
+
+    private ApiResponse(final int code, final String message, final T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(final T data) {
+        return new ApiResponse<>(ErrorCode.OK.getCode(), ErrorCode.OK.getDefaultMessage(), data);
+    }
+
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>(ErrorCode.OK.getCode(), ErrorCode.OK.getDefaultMessage(), null);
+    }
+
+    public static ApiResponse<Void> failure(final ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getCode(), errorCode.getDefaultMessage(), null);
+    }
+
+    public static ApiResponse<Void> failure(final ErrorCode errorCode, final String overrideMessage) {
+        final String message = Objects.requireNonNullElse(overrideMessage, errorCode.getDefaultMessage());
+        return new ApiResponse<>(errorCode.getCode(), message, null);
+    }
+
+    public static <T> ApiResponse<T> failure(final ErrorCode errorCode, final String overrideMessage, final T data) {
+        final String message = Objects.requireNonNullElse(overrideMessage, errorCode.getDefaultMessage());
+        return new ApiResponse<>(errorCode.getCode(), message, data);
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/api/PageResponse.java
+++ b/backend/src/main/java/com/bob/mta/common/api/PageResponse.java
@@ -1,0 +1,53 @@
+package com.bob.mta.common.api;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Pagination metadata container compatible with Ant Design table expectations.
+ *
+ * @param <T> row type
+ */
+public class PageResponse<T> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final List<T> list;
+
+    private final long total;
+
+    private final long page;
+
+    private final long pageSize;
+
+    private PageResponse(final List<T> list, final long total, final long page, final long pageSize) {
+        this.list = list;
+        this.total = total;
+        this.page = page;
+        this.pageSize = pageSize;
+    }
+
+    public static <T> PageResponse<T> of(final List<T> list, final long total, final long page, final long pageSize) {
+        final List<T> safeList = list == null ? Collections.emptyList() : List.copyOf(list);
+        return new PageResponse<>(safeList, total, page, pageSize);
+    }
+
+    public List<T> getList() {
+        return list;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public long getPage() {
+        return page;
+    }
+
+    public long getPageSize() {
+        return pageSize;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bob/mta/common/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.bob.mta.common.config;
+
+import com.bob.mta.common.security.JwtAuthenticationFilter;
+import com.bob.mta.common.security.RestAccessDeniedHandler;
+import com.bob.mta.common.security.RestAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Basic Spring Security configuration wiring JWT filter and public endpoints.
+ */
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter authenticationFilter;
+
+    private final RestAuthenticationEntryPoint authenticationEntryPoint;
+
+    private final RestAccessDeniedHandler accessDeniedHandler;
+
+    public SecurityConfig(
+            final JwtAuthenticationFilter authenticationFilter,
+            final RestAuthenticationEntryPoint authenticationEntryPoint,
+            final RestAccessDeniedHandler accessDeniedHandler) {
+        this.authenticationFilter = authenticationFilter;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(configurer -> configurer
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/ping", "/api/v1/auth/login", "/actuator/health", "/actuator/info").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/exception/BusinessException.java
+++ b/backend/src/main/java/com/bob/mta/common/exception/BusinessException.java
@@ -1,0 +1,23 @@
+package com.bob.mta.common.exception;
+
+/**
+ * Exception representing domain/business rule violations.
+ */
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(final ErrorCode errorCode) {
+        super(errorCode.getDefaultMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(final ErrorCode errorCode, final String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/bob/mta/common/exception/ErrorCode.java
@@ -1,0 +1,31 @@
+package com.bob.mta.common.exception;
+
+/**
+ * Centralized definition of business error codes aligned with the detailed design specification.
+ */
+public enum ErrorCode {
+    OK(0, "success"),
+    BAD_REQUEST(4000, "request.invalid"),
+    UNAUTHORIZED(4010, "auth.required"),
+    FORBIDDEN(4031, "auth.forbidden"),
+    NOT_FOUND(4040, "resource.not_found"),
+    CONFLICT(4090, "operation.conflict"),
+    INTERNAL_ERROR(5000, "system.error");
+
+    private final int code;
+
+    private final String defaultMessage;
+
+    ErrorCode(final int code, final String defaultMessage) {
+        this.code = code;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/bob/mta/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.bob.mta.common.exception;
+
+import com.bob.mta.common.api.ApiResponse;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Converts Java exceptions into unified REST responses while ensuring structured logging.
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(BusinessException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Void> handleBusinessException(final BusinessException ex) {
+        log.warn("Business exception: {}", ex.getMessage());
+        return ApiResponse.failure(ex.getErrorCode(), ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Map<String, String>> handleValidationException(final MethodArgumentNotValidException ex) {
+        final Map<String, String> errors = new HashMap<>();
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fieldError.getField(), Objects.toString(fieldError.getDefaultMessage(), "invalid"));
+        }
+        log.warn("Validation failed: {}", errors);
+        return ApiResponse.failure(ErrorCode.BAD_REQUEST, "validation.failed", errors);
+    }
+
+    @ExceptionHandler({MissingServletRequestParameterException.class, HttpMessageNotReadableException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Void> handleRequestErrors(final Exception ex) {
+        log.warn("Bad request: {}", ex.getMessage());
+        return ApiResponse.failure(ErrorCode.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiResponse<Void> handleUnexpectedException(final Exception ex) {
+        log.error("Unexpected error", ex);
+        return ApiResponse.failure(ErrorCode.INTERNAL_ERROR);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/bob/mta/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.bob.mta.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Reads bearer tokens from the Authorization header and populates the security context.
+ */
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider tokenProvider;
+
+    public JwtAuthenticationFilter(final JwtTokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain)
+            throws ServletException, IOException {
+        final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+            final String token = header.substring(BEARER_PREFIX.length());
+            final Optional<JwtTokenProvider.TokenPayload> payload = tokenProvider.parseToken(token);
+            payload.ifPresent(value -> setAuthentication(request, value));
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthentication(final HttpServletRequest request, final JwtTokenProvider.TokenPayload payload) {
+        final UserDetails principal = User.withUsername(payload.username())
+                .password("N/A")
+                .roles(payload.role())
+                .build();
+        final UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.debug("Authenticated request for user {}", payload.username());
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/JwtProperties.java
+++ b/backend/src/main/java/com/bob/mta/common/security/JwtProperties.java
@@ -1,0 +1,53 @@
+package com.bob.mta.common.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties binding for JWT related configuration.
+ */
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String issuer;
+
+    private AccessToken accessToken = new AccessToken();
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(final String issuer) {
+        this.issuer = issuer;
+    }
+
+    public AccessToken getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(final AccessToken accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public static class AccessToken {
+
+        private String secret;
+
+        private long expirationMinutes = 120;
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(final String secret) {
+            this.secret = secret;
+        }
+
+        public long getExpirationMinutes() {
+            return expirationMinutes;
+        }
+
+        public void setExpirationMinutes(final long expirationMinutes) {
+            this.expirationMinutes = expirationMinutes;
+        }
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/bob/mta/common/security/JwtTokenProvider.java
@@ -1,0 +1,50 @@
+package com.bob.mta.common.security;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Lightweight token provider that encodes authentication context as Base64 payload.
+ * This is a placeholder implementation until a full JWT library is introduced.
+ */
+@Component
+public class JwtTokenProvider {
+
+    private static final String DELIMITER = ":";
+
+    private final JwtProperties properties;
+
+    public JwtTokenProvider(final JwtProperties properties) {
+        this.properties = properties;
+    }
+
+    public String generateToken(final String userId, final String username, final String role) {
+        final Instant expiresAt = Instant.now().plus(properties.getAccessToken().getExpirationMinutes(), ChronoUnit.MINUTES);
+        final String raw = String.join(DELIMITER, properties.getIssuer(), userId, username, role, Long.toString(expiresAt.toEpochMilli()));
+        return Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public Optional<TokenPayload> parseToken(final String token) {
+        try {
+            final String decoded = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
+            final String[] segments = decoded.split(DELIMITER);
+            if (segments.length != 5) {
+                return Optional.empty();
+            }
+            final long expiresAt = Long.parseLong(segments[4]);
+            if (Instant.ofEpochMilli(expiresAt).isBefore(Instant.now())) {
+                return Optional.empty();
+            }
+            return Optional.of(new TokenPayload(segments[0], segments[1], segments[2], segments[3]));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+
+    public record TokenPayload(String issuer, String userId, String username, String role) {
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/RestAccessDeniedHandler.java
+++ b/backend/src/main/java/com/bob/mta/common/security/RestAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.bob.mta.common.security;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * Ensures forbidden responses follow the platform API contract.
+ */
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAccessDeniedHandler(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            final HttpServletRequest request, final HttpServletResponse response, final AccessDeniedException accessDeniedException)
+            throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), ApiResponse.failure(ErrorCode.FORBIDDEN));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/bob/mta/common/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.bob.mta.common.security;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/**
+ * Returns JSON response when anonymous users access protected resources.
+ */
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAuthenticationEntryPoint(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(
+            final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException authException)
+            throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), ApiResponse.failure(ErrorCode.UNAUTHORIZED));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/controller/AuthController.java
@@ -1,0 +1,44 @@
+package com.bob.mta.modules.auth.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.auth.dto.CurrentUserResponse;
+import com.bob.mta.modules.auth.dto.LoginRequest;
+import com.bob.mta.modules.auth.dto.LoginResponse;
+import com.bob.mta.modules.auth.service.AuthService;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoints covering authentication lifecycle.
+ */
+@RestController
+@RequestMapping(path = "/api/v1/auth", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(final AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping(value = "/login", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody final LoginRequest request) {
+        return ApiResponse.success(authService.login(request.getUsername(), request.getPassword()));
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<CurrentUserResponse> currentUser(final Principal principal) {
+        if (principal == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "auth.required");
+        }
+        return ApiResponse.success(authService.currentUser(principal.getName()));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/dto/CurrentUserResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/dto/CurrentUserResponse.java
@@ -1,0 +1,40 @@
+package com.bob.mta.modules.auth.dto;
+
+import java.util.List;
+
+/**
+ * Representation of currently authenticated user for front-end bootstrap.
+ */
+public class CurrentUserResponse {
+
+    private final String userId;
+
+    private final String username;
+
+    private final String displayName;
+
+    private final List<String> roles;
+
+    public CurrentUserResponse(final String userId, final String username, final String displayName, final List<String> roles) {
+        this.userId = userId;
+        this.username = username;
+        this.displayName = displayName;
+        this.roles = List.copyOf(roles);
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/dto/LoginRequest.java
@@ -1,0 +1,31 @@
+package com.bob.mta.modules.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Login form payload.
+ */
+public class LoginRequest {
+
+    @NotBlank(message = "username.required")
+    private String username;
+
+    @NotBlank(message = "password.required")
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/dto/LoginResponse.java
@@ -1,0 +1,33 @@
+package com.bob.mta.modules.auth.dto;
+
+import java.time.Instant;
+
+/**
+ * Authentication response carrying issued token and metadata.
+ */
+public class LoginResponse {
+
+    private final String token;
+
+    private final Instant expiresAt;
+
+    private final String displayName;
+
+    public LoginResponse(final String token, final Instant expiresAt, final String displayName) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.displayName = displayName;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/service/AuthService.java
@@ -1,0 +1,14 @@
+package com.bob.mta.modules.auth.service;
+
+import com.bob.mta.modules.auth.dto.CurrentUserResponse;
+import com.bob.mta.modules.auth.dto.LoginResponse;
+
+/**
+ * Authentication related use cases.
+ */
+public interface AuthService {
+
+    LoginResponse login(String username, String password);
+
+    CurrentUserResponse currentUser(String username);
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/service/impl/InMemoryAuthService.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/service/impl/InMemoryAuthService.java
@@ -1,0 +1,55 @@
+package com.bob.mta.modules.auth.service.impl;
+
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.common.security.JwtProperties;
+import com.bob.mta.common.security.JwtTokenProvider;
+import com.bob.mta.modules.auth.dto.CurrentUserResponse;
+import com.bob.mta.modules.auth.dto.LoginResponse;
+import com.bob.mta.modules.auth.service.AuthService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+/**
+ * Temporary in-memory auth service that mimics future integration with database-backed identities.
+ */
+@Service
+public class InMemoryAuthService implements AuthService {
+
+    private final Map<String, UserRecord> users = Map.of(
+            "admin", new UserRecord("1", "admin", "Admin", "admin123", List.of("ADMIN", "OPERATOR")),
+            "operator", new UserRecord("2", "operator", "Operator", "operator123", List.of("OPERATOR")));
+
+    private final JwtTokenProvider tokenProvider;
+
+    private final JwtProperties properties;
+
+    public InMemoryAuthService(final JwtTokenProvider tokenProvider, final JwtProperties properties) {
+        this.tokenProvider = tokenProvider;
+        this.properties = properties;
+    }
+
+    @Override
+    public LoginResponse login(final String username, final String password) {
+        final UserRecord user = Optional.ofNullable(users.get(username))
+                .filter(record -> record.password().equals(password))
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, "auth.invalid_credentials"));
+        final Instant expiresAt = Instant.now().plus(properties.getAccessToken().getExpirationMinutes(), ChronoUnit.MINUTES);
+        final String token = tokenProvider.generateToken(user.userId(), user.username(), user.roles().get(0));
+        return new LoginResponse(token, expiresAt, user.displayName());
+    }
+
+    @Override
+    public CurrentUserResponse currentUser(final String username) {
+        final UserRecord user = Optional.ofNullable(users.get(username))
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "user.not_found"));
+        return new CurrentUserResponse(user.userId(), user.username(), user.displayName(), user.roles());
+    }
+
+    private record UserRecord(String userId, String username, String displayName, String password, List<String> roles) {
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/controller/CustomerController.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/controller/CustomerController.java
@@ -1,0 +1,41 @@
+package com.bob.mta.modules.customer.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.modules.customer.dto.CustomerDetailResponse;
+import com.bob.mta.modules.customer.dto.CustomerSummaryResponse;
+import com.bob.mta.modules.customer.service.CustomerService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST facade for customer domain operations.
+ */
+@RestController
+@RequestMapping(path = "/api/v1/customers", produces = MediaType.APPLICATION_JSON_VALUE)
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+    public CustomerController(final CustomerService customerService) {
+        this.customerService = customerService;
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<CustomerSummaryResponse>> list(
+            @RequestParam(defaultValue = "1") final int page,
+            @RequestParam(defaultValue = "20") final int pageSize,
+            @RequestParam(required = false) final String keyword,
+            @RequestParam(required = false) final String region) {
+        return ApiResponse.success(customerService.listCustomers(page, pageSize, keyword, region));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<CustomerDetailResponse> detail(@PathVariable final String id) {
+        return ApiResponse.success(customerService.getCustomer(id));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/domain/Customer.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/domain/Customer.java
@@ -1,0 +1,86 @@
+package com.bob.mta.modules.customer.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregate root representing a tenant customer and its dynamic fields.
+ */
+public class Customer {
+
+    private final String id;
+
+    private final String code;
+
+    private final String name;
+
+    private final String shortName;
+
+    private final String group;
+
+    private final String region;
+
+    private final List<String> tags;
+
+    private final Map<String, Object> fields;
+
+    private final Instant updatedAt;
+
+    public Customer(
+            final String id,
+            final String code,
+            final String name,
+            final String shortName,
+            final String group,
+            final String region,
+            final List<String> tags,
+            final Map<String, Object> fields,
+            final Instant updatedAt) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+        this.shortName = shortName;
+        this.group = group;
+        this.region = region;
+        this.tags = List.copyOf(tags);
+        this.fields = Map.copyOf(fields);
+        this.updatedAt = updatedAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public Map<String, Object> getFields() {
+        return fields;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/dto/CustomerDetailResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/dto/CustomerDetailResponse.java
@@ -1,0 +1,86 @@
+package com.bob.mta.modules.customer.dto;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Detailed projection used in the right-hand customer profile panel.
+ */
+public class CustomerDetailResponse {
+
+    private final String id;
+
+    private final String code;
+
+    private final String name;
+
+    private final String shortName;
+
+    private final String group;
+
+    private final String region;
+
+    private final List<String> tags;
+
+    private final Map<String, Object> fields;
+
+    private final Instant updatedAt;
+
+    public CustomerDetailResponse(
+            final String id,
+            final String code,
+            final String name,
+            final String shortName,
+            final String group,
+            final String region,
+            final List<String> tags,
+            final Map<String, Object> fields,
+            final Instant updatedAt) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+        this.shortName = shortName;
+        this.group = group;
+        this.region = region;
+        this.tags = List.copyOf(tags);
+        this.fields = Map.copyOf(fields);
+        this.updatedAt = updatedAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public Map<String, Object> getFields() {
+        return fields;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/dto/CustomerSummaryResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/dto/CustomerSummaryResponse.java
@@ -1,0 +1,69 @@
+package com.bob.mta.modules.customer.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Projection for listing customers in summary views.
+ */
+public class CustomerSummaryResponse {
+
+    private final String id;
+
+    private final String code;
+
+    private final String name;
+
+    private final String group;
+
+    private final String region;
+
+    private final List<String> tags;
+
+    private final Instant updatedAt;
+
+    public CustomerSummaryResponse(
+            final String id,
+            final String code,
+            final String name,
+            final String group,
+            final String region,
+            final List<String> tags,
+            final Instant updatedAt) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+        this.group = group;
+        this.region = region;
+        this.tags = List.copyOf(tags);
+        this.updatedAt = updatedAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/service/CustomerService.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/service/CustomerService.java
@@ -1,0 +1,15 @@
+package com.bob.mta.modules.customer.service;
+
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.modules.customer.dto.CustomerDetailResponse;
+import com.bob.mta.modules.customer.dto.CustomerSummaryResponse;
+
+/**
+ * Customer module operations.
+ */
+public interface CustomerService {
+
+    PageResponse<CustomerSummaryResponse> listCustomers(int page, int pageSize, String keyword, String region);
+
+    CustomerDetailResponse getCustomer(String id);
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/service/impl/InMemoryCustomerService.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/service/impl/InMemoryCustomerService.java
@@ -1,0 +1,129 @@
+package com.bob.mta.modules.customer.service.impl;
+
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.customer.domain.Customer;
+import com.bob.mta.modules.customer.dto.CustomerDetailResponse;
+import com.bob.mta.modules.customer.dto.CustomerSummaryResponse;
+import com.bob.mta.modules.customer.service.CustomerService;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * In-memory implementation providing design-time data for API contracts.
+ */
+@Service
+public class InMemoryCustomerService implements CustomerService {
+
+    private final List<Customer> customers;
+
+    public InMemoryCustomerService() {
+        customers = List.of(
+                new Customer(
+                        "101",
+                        "CUST-101",
+                        "北海道大学",
+                        "北大",
+                        "大学",
+                        "北海道",
+                        List.of("重点客户", "需巡检"),
+                        Map.of(
+                                "接続形態", "VPN",
+                                "接続先IPアドレス", "203.0.113.10",
+                                "接続ツール", List.of("GlobalProtect", "RemoteView"),
+                                "特記事項", "年末年始は保守ウィンドウ停止"),
+                        Instant.parse("2024-05-01T02:30:00Z")),
+                new Customer(
+                        "102",
+                        "CUST-102",
+                        "北見工業大学",
+                        "北見工大",
+                        "大学",
+                        "北海道",
+                        List.of("需更新"),
+                        Map.of(
+                                "接続形態", "専用線",
+                                "接続先IPアドレス", "198.51.100.77",
+                                "接続ツール", List.of("LAPLINK"),
+                                "特記事項", "接続端末は認証デバイス限定"),
+                        Instant.parse("2024-04-11T09:20:00Z")),
+                new Customer(
+                        "201",
+                        "CUST-201",
+                        "东京メトロ",
+                        "东京メトロ",
+                        "交通",
+                        "関東",
+                        List.of("需巡检"),
+                        Map.of(
+                                "接続形態", "VPN",
+                                "接続ツール", List.of("Cisco AnyConnect"),
+                                "特記事項", "夜間帯のみ接続可"),
+                        Instant.parse("2024-04-25T12:00:00Z")));
+    }
+
+    @Override
+    public PageResponse<CustomerSummaryResponse> listCustomers(
+            final int page, final int pageSize, final String keyword, final String region) {
+        final List<Customer> filtered = customers.stream()
+                .filter(customer -> filterByKeyword(customer, keyword))
+                .filter(customer -> filterByRegion(customer, region))
+                .sorted(Comparator.comparing(Customer::getCode))
+                .toList();
+        final int fromIndex = Math.max(0, Math.min(filtered.size(), (page - 1) * pageSize));
+        final int toIndex = Math.max(fromIndex, Math.min(filtered.size(), fromIndex + pageSize));
+        final List<CustomerSummaryResponse> pageData = filtered.subList(fromIndex, toIndex).stream()
+                .map(customer -> new CustomerSummaryResponse(
+                        customer.getId(),
+                        customer.getCode(),
+                        customer.getName(),
+                        customer.getGroup(),
+                        customer.getRegion(),
+                        customer.getTags(),
+                        customer.getUpdatedAt()))
+                .collect(Collectors.toList());
+        return PageResponse.of(pageData, filtered.size(), page, pageSize);
+    }
+
+    @Override
+    public CustomerDetailResponse getCustomer(final String id) {
+        return customers.stream()
+                .filter(customer -> customer.getId().equals(id))
+                .findFirst()
+                .map(customer -> new CustomerDetailResponse(
+                        customer.getId(),
+                        customer.getCode(),
+                        customer.getName(),
+                        customer.getShortName(),
+                        customer.getGroup(),
+                        customer.getRegion(),
+                        customer.getTags(),
+                        customer.getFields(),
+                        customer.getUpdatedAt()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "customer.not_found"));
+    }
+
+    private boolean filterByKeyword(final Customer customer, final String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return true;
+        }
+        final String normalized = keyword.toLowerCase(Locale.ROOT);
+        return customer.getName().toLowerCase(Locale.ROOT).contains(normalized)
+                || customer.getCode().toLowerCase(Locale.ROOT).contains(normalized)
+                || customer.getShortName().toLowerCase(Locale.ROOT).contains(normalized);
+    }
+
+    private boolean filterByRegion(final Customer customer, final String region) {
+        if (!StringUtils.hasText(region)) {
+            return true;
+        }
+        return region.equalsIgnoreCase(customer.getRegion());
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/controller/PlanController.java
@@ -1,0 +1,41 @@
+package com.bob.mta.modules.plan.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.modules.plan.dto.PlanDetailResponse;
+import com.bob.mta.modules.plan.dto.PlanSummaryResponse;
+import com.bob.mta.modules.plan.service.PlanService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * API endpoints exposing plan list and detailed execution views.
+ */
+@RestController
+@RequestMapping(path = "/api/v1/plans", produces = MediaType.APPLICATION_JSON_VALUE)
+public class PlanController {
+
+    private final PlanService planService;
+
+    public PlanController(final PlanService planService) {
+        this.planService = planService;
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<PlanSummaryResponse>> list(
+            @RequestParam(defaultValue = "1") final int page,
+            @RequestParam(defaultValue = "20") final int pageSize,
+            @RequestParam(required = false) final String customerId,
+            @RequestParam(required = false) final String status) {
+        return ApiResponse.success(planService.listPlans(page, pageSize, customerId, status));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<PlanDetailResponse> detail(@PathVariable final String id) {
+        return ApiResponse.success(planService.getPlan(id));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanDetailResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanDetailResponse.java
@@ -1,0 +1,85 @@
+package com.bob.mta.modules.plan.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Detail representation for design/execution view of plan.
+ */
+public class PlanDetailResponse {
+
+    private final String id;
+
+    private final String customerId;
+
+    private final String title;
+
+    private final String description;
+
+    private final Instant startTime;
+
+    private final Instant endTime;
+
+    private final String status;
+
+    private final List<String> assignees;
+
+    private final List<PlanNodeResponse> nodes;
+
+    public PlanDetailResponse(
+            final String id,
+            final String customerId,
+            final String title,
+            final String description,
+            final Instant startTime,
+            final Instant endTime,
+            final String status,
+            final List<String> assignees,
+            final List<PlanNodeResponse> nodes) {
+        this.id = id;
+        this.customerId = customerId;
+        this.title = title;
+        this.description = description;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = status;
+        this.assignees = List.copyOf(assignees);
+        this.nodes = List.copyOf(nodes);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    public Instant getEndTime() {
+        return endTime;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public List<String> getAssignees() {
+        return assignees;
+    }
+
+    public List<PlanNodeResponse> getNodes() {
+        return nodes;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanNodeResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanNodeResponse.java
@@ -1,0 +1,78 @@
+package com.bob.mta.modules.plan.dto;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Node/step inside a maintenance plan.
+ */
+public class PlanNodeResponse {
+
+    private final String id;
+
+    private final String title;
+
+    private final String type;
+
+    private final String status;
+
+    private final Duration estimatedDuration;
+
+    private final Instant startedAt;
+
+    private final Instant completedAt;
+
+    private final List<String> assignees;
+
+    public PlanNodeResponse(
+            final String id,
+            final String title,
+            final String type,
+            final String status,
+            final Duration estimatedDuration,
+            final Instant startedAt,
+            final Instant completedAt,
+            final List<String> assignees) {
+        this.id = id;
+        this.title = title;
+        this.type = type;
+        this.status = status;
+        this.estimatedDuration = estimatedDuration;
+        this.startedAt = startedAt;
+        this.completedAt = completedAt;
+        this.assignees = List.copyOf(assignees);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Duration getEstimatedDuration() {
+        return estimatedDuration;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    public List<String> getAssignees() {
+        return assignees;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanSummaryResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanSummaryResponse.java
@@ -1,0 +1,85 @@
+package com.bob.mta.modules.plan.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Summary of maintenance plan for list/calendar views.
+ */
+public class PlanSummaryResponse {
+
+    private final String id;
+
+    private final String customerId;
+
+    private final String title;
+
+    private final Instant startTime;
+
+    private final Instant endTime;
+
+    private final String status;
+
+    private final List<String> assignees;
+
+    private final int totalNodes;
+
+    private final int completedNodes;
+
+    public PlanSummaryResponse(
+            final String id,
+            final String customerId,
+            final String title,
+            final Instant startTime,
+            final Instant endTime,
+            final String status,
+            final List<String> assignees,
+            final int totalNodes,
+            final int completedNodes) {
+        this.id = id;
+        this.customerId = customerId;
+        this.title = title;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = status;
+        this.assignees = List.copyOf(assignees);
+        this.totalNodes = totalNodes;
+        this.completedNodes = completedNodes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    public Instant getEndTime() {
+        return endTime;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public List<String> getAssignees() {
+        return assignees;
+    }
+
+    public int getTotalNodes() {
+        return totalNodes;
+    }
+
+    public int getCompletedNodes() {
+        return completedNodes;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/service/PlanService.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/service/PlanService.java
@@ -1,0 +1,15 @@
+package com.bob.mta.modules.plan.service;
+
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.modules.plan.dto.PlanDetailResponse;
+import com.bob.mta.modules.plan.dto.PlanSummaryResponse;
+
+/**
+ * Maintenance plan operations.
+ */
+public interface PlanService {
+
+    PageResponse<PlanSummaryResponse> listPlans(int page, int pageSize, String customerId, String status);
+
+    PlanDetailResponse getPlan(String id);
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanService.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanService.java
@@ -1,0 +1,145 @@
+package com.bob.mta.modules.plan.service.impl;
+
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.plan.dto.PlanDetailResponse;
+import com.bob.mta.modules.plan.dto.PlanNodeResponse;
+import com.bob.mta.modules.plan.dto.PlanSummaryResponse;
+import com.bob.mta.modules.plan.service.PlanService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * In-memory plan service describing the execution/ design lifecycle endpoints.
+ */
+@Service
+public class InMemoryPlanService implements PlanService {
+
+    private final Map<String, PlanDetailResponse> plans;
+
+    public InMemoryPlanService() {
+        plans = Map.of(
+                "PLAN-5001",
+                new PlanDetailResponse(
+                        "PLAN-5001",
+                        "101",
+                        "北海道大学 VPN 定期メンテナンス",
+                        "VPNクライアント証明書更新と接続確認を実施",
+                        Instant.parse("2024-05-10T00:00:00Z"),
+                        Instant.parse("2024-05-10T04:00:00Z"),
+                        "IN_PROGRESS",
+                        List.of("admin", "operator"),
+                        List.of(
+                                new PlanNodeResponse(
+                                        "NODE-1",
+                                        "事前バックアップ取得",
+                                        "BACKUP",
+                                        "DONE",
+                                        Duration.ofMinutes(30),
+                                        Instant.parse("2024-05-10T00:00:00Z"),
+                                        Instant.parse("2024-05-10T00:40:00Z"),
+                                        List.of("admin")),
+                                new PlanNodeResponse(
+                                        "NODE-2",
+                                        "VPN証明書更新",
+                                        "OPERATION",
+                                        "IN_PROGRESS",
+                                        Duration.ofMinutes(60),
+                                        Instant.parse("2024-05-10T01:00:00Z"),
+                                        null,
+                                        List.of("operator")),
+                                new PlanNodeResponse(
+                                        "NODE-3",
+                                        "接続確認・報告",
+                                        "VERIFY",
+                                        "PENDING",
+                                        Duration.ofMinutes(30),
+                                        null,
+                                        null,
+                                        List.of("operator")))),
+                "PLAN-5100",
+                new PlanDetailResponse(
+                        "PLAN-5100",
+                        "201",
+                        "东京メトロ 回線切替リハーサル",
+                        "回線切替手順の検証とスクリプト更新",
+                        Instant.parse("2024-05-15T02:00:00Z"),
+                        Instant.parse("2024-05-15T06:00:00Z"),
+                        "DESIGN",
+                        List.of("admin"),
+                        List.of(
+                                new PlanNodeResponse(
+                                        "NODE-1",
+                                        "手順確認ミーティング",
+                                        "MEETING",
+                                        "PENDING",
+                                        Duration.ofMinutes(45),
+                                        null,
+                                        null,
+                                        List.of("admin")),
+                                new PlanNodeResponse(
+                                        "NODE-2",
+                                        "切替スクリプト修正",
+                                        "DOCUMENT",
+                                        "PENDING",
+                                        Duration.ofMinutes(90),
+                                        null,
+                                        null,
+                                        List.of("admin")))));
+    }
+
+    @Override
+    public PageResponse<PlanSummaryResponse> listPlans(
+            final int page, final int pageSize, final String customerId, final String status) {
+        final List<PlanDetailResponse> filtered = plans.values().stream()
+                .filter(plan -> filterByCustomer(plan, customerId))
+                .filter(plan -> filterByStatus(plan, status))
+                .sorted(Comparator.comparing(PlanDetailResponse::getStartTime))
+                .toList();
+        final int fromIndex = Math.max(0, Math.min(filtered.size(), (page - 1) * pageSize));
+        final int toIndex = Math.max(fromIndex, Math.min(filtered.size(), fromIndex + pageSize));
+        final List<PlanSummaryResponse> pageData = filtered.subList(fromIndex, toIndex).stream()
+                .map(plan -> new PlanSummaryResponse(
+                        plan.getId(),
+                        plan.getCustomerId(),
+                        plan.getTitle(),
+                        plan.getStartTime(),
+                        plan.getEndTime(),
+                        plan.getStatus(),
+                        plan.getAssignees(),
+                        plan.getNodes().size(),
+                        (int) plan.getNodes().stream().filter(node -> "DONE".equals(node.getStatus())).count()))
+                .collect(Collectors.toList());
+        return PageResponse.of(pageData, filtered.size(), page, pageSize);
+    }
+
+    @Override
+    public PlanDetailResponse getPlan(final String id) {
+        return plans.entrySet().stream()
+                .filter(entry -> entry.getKey().equals(id))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "plan.not_found"));
+    }
+
+    private boolean filterByCustomer(final PlanDetailResponse plan, final String customerId) {
+        if (!StringUtils.hasText(customerId)) {
+            return true;
+        }
+        return customerId.equalsIgnoreCase(plan.getCustomerId());
+    }
+
+    private boolean filterByStatus(final PlanDetailResponse plan, final String status) {
+        if (!StringUtils.hasText(status)) {
+            return true;
+        }
+        return status.equalsIgnoreCase(plan.getStatus());
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,40 @@
+spring:
+  application:
+    name: bob-mta-backend
+  datasource:
+    url: jdbc:postgresql://localhost:5432/bobmta
+    username: bobmta
+    password: change-me
+    driver-class-name: org.postgresql.Driver
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
+  messages:
+    basename: i18n/messages
+    encoding: UTF-8
+  mvc:
+    format:
+      date-time: yyyy-MM-dd'T'HH:mm:ssXXX
+  sql:
+    init:
+      platform: postgresql
+      mode: never
+server:
+  port: 8080
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+jwt:
+  issuer: bob-mta
+  access-token:
+    secret: change-me-please
+    expiration-minutes: 120
+logging:
+  level:
+    root: INFO
+    com.bob.mta: DEBUG
+  pattern:
+    console: '{"timestamp":"%d{yyyy-MM-dd''T''HH:mm:ss.SSSZ}","level":"%p","logger":"%c{1}","thread":"%t","message":%msg,"trace":%ex}'

--- a/backend/src/main/resources/i18n/messages_ja.properties
+++ b/backend/src/main/resources/i18n/messages_ja.properties
@@ -1,0 +1,4 @@
+app.name=BOB MTA综合运维平台
+app.greeting=いらっしゃいませ、BOB MTAへ
+error.unauthorized=認証が必要です。ログインしてください。
+error.forbidden=権限がありません。管理者にお問い合わせください。

--- a/backend/src/main/resources/i18n/messages_zh.properties
+++ b/backend/src/main/resources/i18n/messages_zh.properties
@@ -1,0 +1,4 @@
+app.name=BOB MTA综合运维平台
+app.greeting=欢迎来到BOB MTA
+error.unauthorized=请登录后继续操作。
+error.forbidden=没有访问权限。请联系管理员。

--- a/backend/src/test/java/com/bob/mta/BobMtaApplicationTests.java
+++ b/backend/src/test/java/com/bob/mta/BobMtaApplicationTests.java
@@ -1,0 +1,12 @@
+package com.bob.mta;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BobMtaApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BOB MTA Maintain Assistants</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bob-mta-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,25 @@
+.app {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0 auto;
+  max-width: 720px;
+  padding: 2rem;
+  line-height: 1.6;
+}
+
+.status-panel {
+  background: #f5f5f5;
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid #e0e0e0;
+  margin-top: 1rem;
+}
+
+.success {
+  color: #237804;
+  font-weight: 600;
+}
+
+.error {
+  color: #cf1322;
+  font-weight: 600;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import './App.css';
+
+type PingResponse = {
+  status: string;
+};
+
+function App() {
+  const [ping, setPing] = useState<PingResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/ping')
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const body = (await response.json()) as PingResponse;
+        setPing(body);
+      })
+      .catch((err) => {
+        setError(err.message);
+      });
+  }, []);
+
+  return (
+    <div className="app">
+      <h1>BOB MTA Maintain Assistants</h1>
+      <p>最简前后端联通性验证页面。</p>
+      <section className="status-panel">
+        <h2>后端连通性</h2>
+        {ping && <p className="success">后端响应：{ping.status}</p>}
+        {error && <p className="error">请求失败：{error}</p>}
+        {!ping && !error && <p>检查后端连接中...</p>}
+      </section>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,15 @@
+:root {
+  color-scheme: light dark;
+  background-color: #ffffff;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: #ffffff;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.spec.tsx"]
+}

--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "scripts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add common response envelope, error handling, and JWT-based security skeleton for backend services
- implement auth, customer, and plan module controllers with in-memory data aligned to the design specification
- configure backend application properties and seed multilingual resource bundles for future i18n support

## Testing
- not run (per instructions to skip automated tests in this iteration)

------
https://chatgpt.com/codex/tasks/task_e_68d64d6accb4832f9adebad11b0bbaa1