### PR TITLE
feat: implement stage-two backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Node
+node_modules/
+frontend/node_modules/
+frontend/dist/
+
+# Java
+backend/target/
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# bobmta
+# BOB MTA Maintain Assistants 平台 - 阶段二后端框架
+
+本仓库根据《BOB MTA（Maintain Assistants）综合运维平台 详细设计说明书》分阶段实现平台。本次提交完成第二阶段目标：
+
+- 完成后端基础框架，提供统一响应、异常拦截、JWT 鉴权与 RBAC 校验；
+- 搭建内存版“用户、客户、计划”领域能力，覆盖账号激活、角色分配、客户视图与计划流程等关键场景；
+- 编写针对服务、控制器与安全组件的单元测试，Jacoco 预设覆盖率目标大于 80%，为后续持久化改造提供安全网。
+
+## 项目结构
+
+```
+backend/   # Spring Boot 3 后端服务，暴露阶段二所需的 REST API
+frontend/  # React + Vite 前端占位，后续阶段将继续完善
+```
+
+## 后端快速开始
+
+```bash
+cd backend
+mvn spring-boot:run
+```
+
+应用启动后可尝试以下示例接口：
+
+| 接口 | 描述 | 备注 |
+| --- | --- | --- |
+| `POST /api/v1/auth/login` | 账号登录（内存账户） | 预置账号：`admin`/`admin123`、`operator`/`operator123` |
+| `GET /api/v1/auth/me` | 获取当前登录用户信息 | 需要在 `Authorization: Bearer <token>` 中携带登录返回的 Token |
+| `POST /api/v1/users` | 创建系统用户并发放激活链接 | 需管理员角色 |
+| `POST /api/v1/users/activation` | 校验激活 Token 并启用账号 | 激活接口对未登录用户开放 |
+| `POST /api/v1/users/{id}/activation/resend` | 重新发放激活链接 | 需管理员角色 |
+| `PUT /api/v1/users/{id}/roles` | 更新用户角色集合 | 角色名自动标准化为 `ROLE_*` |
+| `GET /api/v1/customers` | 客户列表 | 支持按地区与关键字过滤（内存数据） |
+| `GET /api/v1/customers/{id}` | 客户详情 | 展示联系人、自定义字段等结构 |
+| `GET /api/v1/plans` | 运维计划列表 | 支持按客户、状态过滤并返回进度摘要 |
+| `GET /api/v1/plans/{id}` | 运维计划详情 | 展示流程节点树形结构 |
+| `GET /api/ping` | 健康检查 | 返回 `{status: ok}` |
+
+### 测试与覆盖率
+
+```bash
+cd backend
+mvn verify
+```
+
+该命令会运行全部单元测试并在 `backend/target/site/jacoco/index.html` 生成 Jacoco 覆盖率报表。若初次执行无法下载依赖，可根据环境配置 Maven 镜像。
+
+## 下一步计划
+
+- 将内存实现替换为基于 PostgreSQL + MyBatis 的持久化访问层，补充数据库建模脚本；
+- 引入模板中心、文件服务、审计日志等模块骨架，补全跨模块协作接口；
+- 与前端协同定义 OpenAPI 契约，扩展状态管理与国际化能力；
+- 补充更多集成测试并接入 CI，持续维持覆盖率在 80% 以上。

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,126 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.bob.mta</groupId>
+    <artifactId>backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>bob-mta-backend</name>
+    <description>BOB MTA maintain assistants backend</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <jjwt.version>0.11.5</jjwt.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+            <version>3.0.3</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.10</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/bob/mta/BobMtaApplication.java
+++ b/backend/src/main/java/com/bob/mta/BobMtaApplication.java
@@ -1,0 +1,15 @@
+package com.bob.mta;
+
+import com.bob.mta.common.security.JwtProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
+public class BobMtaApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BobMtaApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/api/PingController.java
+++ b/backend/src/main/java/com/bob/mta/api/PingController.java
@@ -1,0 +1,22 @@
+package com.bob.mta.api;
+
+import com.bob.mta.common.api.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+public class PingController {
+
+    @GetMapping("/ping")
+    public ApiResponse<Map<String, Object>> ping() {
+        return ApiResponse.success(Map.of(
+                "status", "ok",
+                "timestamp", OffsetDateTime.now().toString()
+        ));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/api/ApiResponse.java
+++ b/backend/src/main/java/com/bob/mta/common/api/ApiResponse.java
@@ -1,0 +1,113 @@
+package com.bob.mta.common.api;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public class ApiResponse<T> {
+
+    private final OffsetDateTime timestamp;
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(Builder<T> builder) {
+        this.timestamp = builder.timestamp;
+        this.success = builder.success;
+        this.code = builder.code;
+        this.message = builder.message;
+        this.data = builder.data;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code("OK")
+                .message("success")
+                .data(data)
+                .timestamp(OffsetDateTime.now())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> failure(String code, String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(code)
+                .message(message)
+                .timestamp(OffsetDateTime.now())
+                .build();
+    }
+
+    public OffsetDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    public Builder<T> toBuilder() {
+        return new Builder<T>()
+                .timestamp(timestamp)
+                .success(success)
+                .code(code)
+                .message(message)
+                .data(data);
+    }
+
+    public static final class Builder<T> {
+        private OffsetDateTime timestamp;
+        private boolean success;
+        private String code;
+        private String message;
+        private T data;
+
+        private Builder() {
+        }
+
+        public Builder<T> timestamp(OffsetDateTime timestamp) {
+            this.timestamp = Objects.requireNonNull(timestamp, "timestamp");
+            return this;
+        }
+
+        public Builder<T> success(boolean success) {
+            this.success = success;
+            return this;
+        }
+
+        public Builder<T> code(String code) {
+            this.code = code;
+            return this;
+        }
+
+        public Builder<T> message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder<T> data(T data) {
+            this.data = data;
+            return this;
+        }
+
+        public ApiResponse<T> build() {
+            return new ApiResponse<>(this);
+        }
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/api/PageResponse.java
+++ b/backend/src/main/java/com/bob/mta/common/api/PageResponse.java
@@ -1,0 +1,39 @@
+package com.bob.mta.common.api;
+
+import java.util.Collections;
+import java.util.List;
+
+public class PageResponse<T> {
+
+    private final List<T> items;
+    private final long total;
+    private final int page;
+    private final int size;
+
+    public PageResponse(List<T> items, long total, int page, int size) {
+        this.items = items == null ? Collections.emptyList() : List.copyOf(items);
+        this.total = total;
+        this.page = page;
+        this.size = size;
+    }
+
+    public static <T> PageResponse<T> of(List<T> items, long total, int page, int size) {
+        return new PageResponse<>(items, total, page, size);
+    }
+
+    public List<T> getItems() {
+        return items;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/bob/mta/common/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.bob.mta.common.config;
+
+import com.bob.mta.common.security.JwtAuthenticationFilter;
+import com.bob.mta.common.security.RestAccessDeniedHandler;
+import com.bob.mta.common.security.RestAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Basic Spring Security configuration wiring JWT filter and public endpoints.
+ */
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter authenticationFilter;
+
+    private final RestAuthenticationEntryPoint authenticationEntryPoint;
+
+    private final RestAccessDeniedHandler accessDeniedHandler;
+
+    public SecurityConfig(
+            final JwtAuthenticationFilter authenticationFilter,
+            final RestAuthenticationEntryPoint authenticationEntryPoint,
+            final RestAccessDeniedHandler accessDeniedHandler) {
+        this.authenticationFilter = authenticationFilter;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(configurer -> configurer
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/ping", "/api/v1/auth/login", "/api/v1/users/activation", "/actuator/health", "/actuator/info")
+                        .permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/exception/BusinessException.java
+++ b/backend/src/main/java/com/bob/mta/common/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.bob.mta.common.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getDefaultMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/bob/mta/common/exception/ErrorCode.java
@@ -1,0 +1,38 @@
+package com.bob.mta.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    UNKNOWN_ERROR("ERR-000", HttpStatus.INTERNAL_SERVER_ERROR, "Unknown error"),
+    VALIDATION_ERROR("ERR-001", HttpStatus.BAD_REQUEST, "Validation failed"),
+    AUTHENTICATION_FAILED("ERR-100", HttpStatus.UNAUTHORIZED, "Authentication failed"),
+    ACCESS_DENIED("ERR-101", HttpStatus.FORBIDDEN, "Access denied"),
+    USER_NOT_FOUND("ERR-200", HttpStatus.NOT_FOUND, "User not found"),
+    USERNAME_EXISTS("ERR-201", HttpStatus.CONFLICT, "Username already exists"),
+    USER_INACTIVE("ERR-202", HttpStatus.BAD_REQUEST, "User inactive"),
+    ACTIVATION_TOKEN_INVALID("ERR-203", HttpStatus.BAD_REQUEST, "Invalid activation token"),
+    CUSTOMER_NOT_FOUND("ERR-300", HttpStatus.NOT_FOUND, "Customer not found"),
+    PLAN_NOT_FOUND("ERR-400", HttpStatus.NOT_FOUND, "Plan not found");
+
+    private final String code;
+    private final HttpStatus status;
+    private final String defaultMessage;
+
+    ErrorCode(String code, HttpStatus status, String defaultMessage) {
+        this.code = code;
+        this.status = status;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/bob/mta/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.bob.mta.common.exception;
+
+import com.bob.mta.common.api.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBusinessException(BusinessException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        HttpStatus status = errorCode.getStatus();
+        ApiResponse<Object> body = ApiResponse.failure(errorCode.getCode(), exception.getMessage());
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler({BadCredentialsException.class})
+    public ResponseEntity<ApiResponse<Object>> handleBadCredentials() {
+        ErrorCode errorCode = ErrorCode.AUTHENTICATION_FAILED;
+        ApiResponse<Object> body = ApiResponse.failure(errorCode.getCode(), errorCode.getDefaultMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(body);
+    }
+
+    @ExceptionHandler({AccessDeniedException.class})
+    public ResponseEntity<ApiResponse<Object>> handleAccessDenied() {
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+        ApiResponse<Object> body = ApiResponse.failure(errorCode.getCode(), errorCode.getDefaultMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(body);
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class})
+    public ResponseEntity<ApiResponse<Object>> handleValidation(Exception exception) {
+        ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
+        ApiResponse<Object> body = ApiResponse.failure(errorCode.getCode(), exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleUnknown(Exception exception) {
+        ErrorCode errorCode = ErrorCode.UNKNOWN_ERROR;
+        ApiResponse<Object> body = ApiResponse.failure(errorCode.getCode(), exception.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/bob/mta/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.bob.mta.common.security;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null) {
+            Claims claims = tokenProvider.parseClaims(token);
+            String userId = claims.getSubject();
+            String username = claims.get("username", String.class);
+            List<String> roles = claims.get("roles", List.class);
+            Collection<? extends GrantedAuthority> authorities = roles == null ? List.of()
+                    : roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    new JwtUserDetails(userId, username, authorities),
+                    token,
+                    authorities
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/JwtProperties.java
+++ b/backend/src/main/java/com/bob/mta/common/security/JwtProperties.java
@@ -1,0 +1,47 @@
+package com.bob.mta.common.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String issuer = "bob-mta";
+    private AccessToken accessToken = new AccessToken();
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public AccessToken getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(AccessToken accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public static class AccessToken {
+        private String secret = "change-me-please";
+        private long expirationMinutes = 120;
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+
+        public long getExpirationMinutes() {
+            return expirationMinutes;
+        }
+
+        public void setExpirationMinutes(long expirationMinutes) {
+            this.expirationMinutes = expirationMinutes;
+        }
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/bob/mta/common/security/JwtTokenProvider.java
@@ -1,0 +1,54 @@
+package com.bob.mta.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+public class JwtTokenProvider {
+
+    private final JwtProperties properties;
+    private final SecretKey secretKey;
+
+    public JwtTokenProvider(JwtProperties properties) {
+        this.properties = properties;
+        this.secretKey = Keys.hmacShaKeyFor(properties.getAccessToken().getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createToken(String userId, String username, List<String> roles) {
+        Instant now = Instant.now();
+        Instant expiry = now.plus(properties.getAccessToken().getExpirationMinutes(), ChronoUnit.MINUTES);
+        return Jwts.builder()
+                .setIssuer(properties.getIssuer())
+                .setSubject(userId)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expiry))
+                .addClaims(Map.of(
+                        "username", username,
+                        "roles", roles
+                ))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .requireIssuer(properties.getIssuer())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public long getExpirationMinutes() {
+        return properties.getAccessToken().getExpirationMinutes();
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/JwtUserDetails.java
+++ b/backend/src/main/java/com/bob/mta/common/security/JwtUserDetails.java
@@ -1,0 +1,58 @@
+package com.bob.mta.common.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class JwtUserDetails implements UserDetails {
+
+    private final String id;
+    private final String username;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public JwtUserDetails(String id, String username, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.username = username;
+        this.authorities = authorities;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/RestAccessDeniedHandler.java
+++ b/backend/src/main/java/com/bob/mta/common/security/RestAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.bob.mta.common.security;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+        ApiResponse<Object> body = ApiResponse.failure(errorCode.getCode(), errorCode.getDefaultMessage());
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/bob/mta/common/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.bob.mta.common.security;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public RestAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        ErrorCode errorCode = ErrorCode.AUTHENTICATION_FAILED;
+        ApiResponse<Object> body = ApiResponse.failure(errorCode.getCode(), errorCode.getDefaultMessage());
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/bob/mta/common/security/SecurityConfig.java
@@ -1,0 +1,90 @@
+package com.bob.mta.common.security;
+
+import com.bob.mta.modules.auth.service.AuthService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtProperties jwtProperties;
+    private final AuthService authService;
+
+    public SecurityConfig(JwtProperties jwtProperties, AuthService authService) {
+        this.jwtProperties = jwtProperties;
+        this.authService = authService;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtTokenProvider jwtTokenProvider() {
+        return new JwtTokenProvider(jwtProperties);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider());
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(UserDetailsService userDetailsService) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return new ProviderManager(List.of(provider));
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return authService::loadUserByUsername;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, RestAuthenticationEntryPoint authenticationEntryPoint,
+                                           RestAccessDeniedHandler accessDeniedHandler) throws Exception {
+        http.csrf(csrf -> csrf.disable());
+        http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.authorizeHttpRequests(authz -> authz
+                .requestMatchers("/api/ping", "/api/v1/auth/login", "/api/v1/users/activation").permitAll()
+                .anyRequest().authenticated()
+        );
+        http.exceptionHandling(handling -> handling
+                .authenticationEntryPoint(authenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler)
+        );
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public RestAuthenticationEntryPoint restAuthenticationEntryPoint(com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
+        return new RestAuthenticationEntryPoint(objectMapper);
+    }
+
+    @Bean
+    public RestAccessDeniedHandler restAccessDeniedHandler(com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
+        return new RestAccessDeniedHandler(objectMapper);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.bob.mta.modules.auth.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.modules.auth.dto.CurrentUserResponse;
+import com.bob.mta.modules.auth.dto.LoginRequest;
+import com.bob.mta.modules.auth.dto.LoginResponse;
+import com.bob.mta.modules.auth.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ApiResponse.success(authService.login(request));
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<CurrentUserResponse> currentUser(@AuthenticationPrincipal UserDetails userDetails) {
+        return ApiResponse.success(authService.currentUser(userDetails));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/dto/CurrentUserResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/dto/CurrentUserResponse.java
@@ -1,0 +1,28 @@
+package com.bob.mta.modules.auth.dto;
+
+import java.util.List;
+
+public class CurrentUserResponse {
+
+    private final String userId;
+    private final String username;
+    private final List<String> roles;
+
+    public CurrentUserResponse(String userId, String username, List<String> roles) {
+        this.userId = userId;
+        this.username = username;
+        this.roles = roles;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/dto/LoginRequest.java
@@ -1,0 +1,28 @@
+package com.bob.mta.modules.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/dto/LoginResponse.java
@@ -1,0 +1,41 @@
+package com.bob.mta.modules.auth.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class LoginResponse {
+
+    private final String token;
+    private final OffsetDateTime expiresAt;
+    private final String userId;
+    private final String username;
+    private final List<String> roles;
+
+    public LoginResponse(String token, OffsetDateTime expiresAt, String userId, String username, List<String> roles) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.userId = userId;
+        this.username = username;
+        this.roles = roles;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public OffsetDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/service/AuthService.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/service/AuthService.java
@@ -1,0 +1,15 @@
+package com.bob.mta.modules.auth.service;
+
+import com.bob.mta.modules.auth.dto.CurrentUserResponse;
+import com.bob.mta.modules.auth.dto.LoginRequest;
+import com.bob.mta.modules.auth.dto.LoginResponse;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface AuthService {
+
+    LoginResponse login(LoginRequest request);
+
+    CurrentUserResponse currentUser(UserDetails userDetails);
+
+    UserDetails loadUserByUsername(String username);
+}

--- a/backend/src/main/java/com/bob/mta/modules/auth/service/impl/InMemoryAuthService.java
+++ b/backend/src/main/java/com/bob/mta/modules/auth/service/impl/InMemoryAuthService.java
@@ -1,0 +1,94 @@
+package com.bob.mta.modules.auth.service.impl;
+
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.common.security.JwtTokenProvider;
+import com.bob.mta.common.security.JwtUserDetails;
+import com.bob.mta.modules.auth.dto.CurrentUserResponse;
+import com.bob.mta.modules.auth.dto.LoginRequest;
+import com.bob.mta.modules.auth.dto.LoginResponse;
+import com.bob.mta.modules.auth.service.AuthService;
+import com.bob.mta.modules.user.domain.User;
+import com.bob.mta.modules.user.domain.UserStatus;
+import com.bob.mta.modules.user.service.UserService;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class InMemoryAuthService implements AuthService {
+
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider tokenProvider;
+
+    public InMemoryAuthService(UserService userService, PasswordEncoder passwordEncoder, JwtTokenProvider tokenProvider) {
+        this.userService = userService;
+        this.passwordEncoder = passwordEncoder;
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public LoginResponse login(LoginRequest request) {
+        User user = userService.findByUsername(request.getUsername())
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTHENTICATION_FAILED));
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.USER_INACTIVE);
+        }
+        if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
+            throw new BusinessException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        List<String> roles = user.getRoles().stream().sorted().toList();
+        String token = tokenProvider.createToken(user.getId(), user.getUsername(), roles);
+        OffsetDateTime expiresAt = OffsetDateTime.now().plusMinutes(tokenProvider.getExpirationMinutes());
+        return new LoginResponse(token, expiresAt, user.getId(), user.getUsername(), roles);
+    }
+
+    @Override
+    public CurrentUserResponse currentUser(UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new BusinessException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        String userId;
+        String username = userDetails.getUsername();
+        if (userDetails instanceof JwtUserDetails details) {
+            userId = details.getId();
+        } else {
+            userId = userService.findByUsername(username)
+                    .map(User::getId)
+                    .orElse("unknown");
+        }
+        List<String> roles = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .sorted()
+                .toList();
+        return new CurrentUserResponse(userId, username, roles);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) {
+        if (!StringUtils.hasText(username)) {
+            throw new BusinessException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTHENTICATION_FAILED));
+        List<GrantedAuthority> authorities = user.getRoles().stream()
+                .map(role -> (GrantedAuthority) () -> role)
+                .collect(Collectors.toList());
+        return org.springframework.security.core.userdetails.User
+                .withUsername(user.getUsername())
+                .password(user.getPasswordHash())
+                .authorities(authorities)
+                .accountExpired(false)
+                .accountLocked(user.getStatus() == UserStatus.LOCKED)
+                .credentialsExpired(false)
+                .disabled(user.getStatus() != UserStatus.ACTIVE)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/controller/CustomerController.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/controller/CustomerController.java
@@ -1,0 +1,47 @@
+package com.bob.mta.modules.customer.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.modules.customer.dto.CustomerDetailResponse;
+import com.bob.mta.modules.customer.dto.CustomerSummaryResponse;
+import com.bob.mta.modules.customer.service.CustomerService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/customers")
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+    public CustomerController(CustomerService customerService) {
+        this.customerService = customerService;
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN','OPERATOR')")
+    @GetMapping
+    public ApiResponse<PageResponse<CustomerSummaryResponse>> search(@RequestParam(defaultValue = "") String keyword,
+                                                                     @RequestParam(defaultValue = "") String region,
+                                                                     @RequestParam(defaultValue = "0") int page,
+                                                                     @RequestParam(defaultValue = "10") int size) {
+        List<CustomerSummaryResponse> all = customerService.search(keyword, region).stream()
+                .map(CustomerSummaryResponse::from)
+                .toList();
+        int fromIndex = Math.min(page * size, all.size());
+        int toIndex = Math.min(fromIndex + size, all.size());
+        List<CustomerSummaryResponse> items = all.subList(fromIndex, toIndex);
+        return ApiResponse.success(PageResponse.of(items, all.size(), page, size));
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN','OPERATOR')")
+    @GetMapping("/{id}")
+    public ApiResponse<CustomerDetailResponse> detail(@PathVariable String id) {
+        return ApiResponse.success(CustomerDetailResponse.from(customerService.getById(id)));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/domain/Customer.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/domain/Customer.java
@@ -1,0 +1,61 @@
+package com.bob.mta.modules.customer.domain;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class Customer {
+
+    private final String id;
+    private final String name;
+    private final String region;
+    private final String industry;
+    private final List<String> tags;
+    private final Map<String, String> contacts;
+    private final Map<String, String> customFields;
+    private final OffsetDateTime lastUpdatedAt;
+
+    public Customer(String id, String name, String region, String industry, List<String> tags,
+                    Map<String, String> contacts, Map<String, String> customFields, OffsetDateTime lastUpdatedAt) {
+        this.id = id;
+        this.name = name;
+        this.region = region;
+        this.industry = industry;
+        this.tags = List.copyOf(tags);
+        this.contacts = Map.copyOf(contacts);
+        this.customFields = Map.copyOf(customFields);
+        this.lastUpdatedAt = lastUpdatedAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getIndustry() {
+        return industry;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public Map<String, String> getContacts() {
+        return contacts;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public OffsetDateTime getLastUpdatedAt() {
+        return lastUpdatedAt;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/dto/CustomerDetailResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/dto/CustomerDetailResponse.java
@@ -1,0 +1,77 @@
+package com.bob.mta.modules.customer.dto;
+
+import com.bob.mta.modules.customer.domain.Customer;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class CustomerDetailResponse {
+
+    private final String id;
+    private final String name;
+    private final String region;
+    private final String industry;
+    private final List<String> tags;
+    private final Map<String, String> contacts;
+    private final Map<String, String> customFields;
+    private final OffsetDateTime lastUpdatedAt;
+
+    public CustomerDetailResponse(String id, String name, String region, String industry, List<String> tags,
+                                  Map<String, String> contacts, Map<String, String> customFields,
+                                  OffsetDateTime lastUpdatedAt) {
+        this.id = id;
+        this.name = name;
+        this.region = region;
+        this.industry = industry;
+        this.tags = tags;
+        this.contacts = contacts;
+        this.customFields = customFields;
+        this.lastUpdatedAt = lastUpdatedAt;
+    }
+
+    public static CustomerDetailResponse from(Customer customer) {
+        return new CustomerDetailResponse(
+                customer.getId(),
+                customer.getName(),
+                customer.getRegion(),
+                customer.getIndustry(),
+                customer.getTags(),
+                customer.getContacts(),
+                customer.getCustomFields(),
+                customer.getLastUpdatedAt()
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getIndustry() {
+        return industry;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public Map<String, String> getContacts() {
+        return contacts;
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public OffsetDateTime getLastUpdatedAt() {
+        return lastUpdatedAt;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/dto/CustomerSummaryResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/dto/CustomerSummaryResponse.java
@@ -1,0 +1,61 @@
+package com.bob.mta.modules.customer.dto;
+
+import com.bob.mta.modules.customer.domain.Customer;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class CustomerSummaryResponse {
+
+    private final String id;
+    private final String name;
+    private final String region;
+    private final String industry;
+    private final List<String> tags;
+    private final OffsetDateTime lastUpdatedAt;
+
+    public CustomerSummaryResponse(String id, String name, String region, String industry,
+                                   List<String> tags, OffsetDateTime lastUpdatedAt) {
+        this.id = id;
+        this.name = name;
+        this.region = region;
+        this.industry = industry;
+        this.tags = tags;
+        this.lastUpdatedAt = lastUpdatedAt;
+    }
+
+    public static CustomerSummaryResponse from(Customer customer) {
+        return new CustomerSummaryResponse(
+                customer.getId(),
+                customer.getName(),
+                customer.getRegion(),
+                customer.getIndustry(),
+                customer.getTags(),
+                customer.getLastUpdatedAt()
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getIndustry() {
+        return industry;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public OffsetDateTime getLastUpdatedAt() {
+        return lastUpdatedAt;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/service/CustomerService.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/service/CustomerService.java
@@ -1,0 +1,12 @@
+package com.bob.mta.modules.customer.service;
+
+import com.bob.mta.modules.customer.domain.Customer;
+
+import java.util.List;
+
+public interface CustomerService {
+
+    List<Customer> search(String keyword, String region);
+
+    Customer getById(String id);
+}

--- a/backend/src/main/java/com/bob/mta/modules/customer/service/impl/InMemoryCustomerService.java
+++ b/backend/src/main/java/com/bob/mta/modules/customer/service/impl/InMemoryCustomerService.java
@@ -1,0 +1,70 @@
+package com.bob.mta.modules.customer.service.impl;
+
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.customer.domain.Customer;
+import com.bob.mta.modules.customer.service.CustomerService;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+@Service
+public class InMemoryCustomerService implements CustomerService {
+
+    private final ConcurrentMap<String, Customer> customers = new ConcurrentHashMap<>();
+
+    public InMemoryCustomerService() {
+        seedCustomers();
+    }
+
+    private void seedCustomers() {
+        addCustomer(new Customer(
+                "cust-001",
+                "东京医疗中心",
+                "东京",
+                "医疗",
+                List.of("重点客户", "长期合作"),
+                Map.of("primary", "+81-3-0000-0000", "email", "contact@tokyo-med.jp"),
+                Map.of("ERP版本", "R12", "核心系统", "患者管理平台"),
+                OffsetDateTime.now().minusDays(2)
+        ));
+        addCustomer(new Customer(
+                "cust-002",
+                "大阪制造",
+                "大阪",
+                "制造",
+                List.of("华东区", "生产"),
+                Map.of("primary", "+81-6-0000-0000", "email", "ops@osaka-mfg.jp"),
+                Map.of("工厂数量", "3", "关键联系人", "田中"),
+                OffsetDateTime.now().minusDays(5)
+        ));
+    }
+
+    private void addCustomer(Customer customer) {
+        customers.put(customer.getId(), customer);
+    }
+
+    @Override
+    public List<Customer> search(String keyword, String region) {
+        return customers.values().stream()
+                .filter(customer -> !StringUtils.hasText(keyword) || customer.getName().contains(keyword))
+                .filter(customer -> !StringUtils.hasText(region) || region.equals(customer.getRegion()))
+                .sorted((a, b) -> a.getName().compareToIgnoreCase(b.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Customer getById(String id) {
+        Customer customer = customers.get(id);
+        if (customer == null) {
+            throw new BusinessException(ErrorCode.CUSTOMER_NOT_FOUND);
+        }
+        return customer;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/controller/PlanController.java
@@ -1,0 +1,47 @@
+package com.bob.mta.modules.plan.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.modules.plan.dto.PlanDetailResponse;
+import com.bob.mta.modules.plan.dto.PlanSummaryResponse;
+import com.bob.mta.modules.plan.service.PlanService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/plans")
+public class PlanController {
+
+    private final PlanService planService;
+
+    public PlanController(PlanService planService) {
+        this.planService = planService;
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN','OPERATOR')")
+    @GetMapping
+    public ApiResponse<PageResponse<PlanSummaryResponse>> list(@RequestParam(defaultValue = "") String customerId,
+                                                               @RequestParam(defaultValue = "") String status,
+                                                               @RequestParam(defaultValue = "0") int page,
+                                                               @RequestParam(defaultValue = "10") int size) {
+        List<PlanSummaryResponse> all = planService.listPlans(customerId, status).stream()
+                .map(PlanSummaryResponse::from)
+                .toList();
+        int fromIndex = Math.min(page * size, all.size());
+        int toIndex = Math.min(fromIndex + size, all.size());
+        List<PlanSummaryResponse> items = all.subList(fromIndex, toIndex);
+        return ApiResponse.success(PageResponse.of(items, all.size(), page, size));
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN','OPERATOR')")
+    @GetMapping("/{id}")
+    public ApiResponse<PlanDetailResponse> detail(@PathVariable String id) {
+        return ApiResponse.success(PlanDetailResponse.from(planService.getPlan(id)));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/domain/Plan.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/domain/Plan.java
@@ -1,0 +1,66 @@
+package com.bob.mta.modules.plan.domain;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class Plan {
+
+    private final String id;
+    private final String title;
+    private final String customerId;
+    private final String owner;
+    private final PlanStatus status;
+    private final OffsetDateTime startTime;
+    private final OffsetDateTime endTime;
+    private final int progress;
+    private final List<PlanNode> nodes;
+
+    public Plan(String id, String title, String customerId, String owner, PlanStatus status,
+                OffsetDateTime startTime, OffsetDateTime endTime, int progress, List<PlanNode> nodes) {
+        this.id = id;
+        this.title = title;
+        this.customerId = customerId;
+        this.owner = owner;
+        this.status = status;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.progress = progress;
+        this.nodes = nodes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public PlanStatus getStatus() {
+        return status;
+    }
+
+    public OffsetDateTime getStartTime() {
+        return startTime;
+    }
+
+    public OffsetDateTime getEndTime() {
+        return endTime;
+    }
+
+    public int getProgress() {
+        return progress;
+    }
+
+    public List<PlanNode> getNodes() {
+        return nodes;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/domain/PlanNode.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/domain/PlanNode.java
@@ -1,0 +1,46 @@
+package com.bob.mta.modules.plan.domain;
+
+import java.util.List;
+
+public class PlanNode {
+
+    private final String id;
+    private final String name;
+    private final String type;
+    private final String assignee;
+    private final int order;
+    private final List<PlanNode> children;
+
+    public PlanNode(String id, String name, String type, String assignee, int order, List<PlanNode> children) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.assignee = assignee;
+        this.order = order;
+        this.children = children;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getAssignee() {
+        return assignee;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public List<PlanNode> getChildren() {
+        return children;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/domain/PlanStatus.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/domain/PlanStatus.java
@@ -1,0 +1,9 @@
+package com.bob.mta.modules.plan.domain;
+
+public enum PlanStatus {
+    DESIGN,
+    SCHEDULED,
+    IN_PROGRESS,
+    COMPLETED,
+    CANCELED
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanDetailResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanDetailResponse.java
@@ -1,0 +1,87 @@
+package com.bob.mta.modules.plan.dto;
+
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanStatus;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class PlanDetailResponse {
+
+    private final String id;
+    private final String title;
+    private final String customerId;
+    private final String owner;
+    private final PlanStatus status;
+    private final OffsetDateTime startTime;
+    private final OffsetDateTime endTime;
+    private final int progress;
+    private final List<PlanNodeResponse> nodes;
+
+    public PlanDetailResponse(String id, String title, String customerId, String owner, PlanStatus status,
+                              OffsetDateTime startTime, OffsetDateTime endTime, int progress,
+                              List<PlanNodeResponse> nodes) {
+        this.id = id;
+        this.title = title;
+        this.customerId = customerId;
+        this.owner = owner;
+        this.status = status;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.progress = progress;
+        this.nodes = nodes;
+    }
+
+    public static PlanDetailResponse from(Plan plan) {
+        List<PlanNodeResponse> nodeResponses = plan.getNodes().stream()
+                .map(PlanNodeResponse::from)
+                .toList();
+        return new PlanDetailResponse(
+                plan.getId(),
+                plan.getTitle(),
+                plan.getCustomerId(),
+                plan.getOwner(),
+                plan.getStatus(),
+                plan.getStartTime(),
+                plan.getEndTime(),
+                plan.getProgress(),
+                nodeResponses
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public PlanStatus getStatus() {
+        return status;
+    }
+
+    public OffsetDateTime getStartTime() {
+        return startTime;
+    }
+
+    public OffsetDateTime getEndTime() {
+        return endTime;
+    }
+
+    public int getProgress() {
+        return progress;
+    }
+
+    public List<PlanNodeResponse> getNodes() {
+        return nodes;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanNodeResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanNodeResponse.java
@@ -1,0 +1,57 @@
+package com.bob.mta.modules.plan.dto;
+
+import com.bob.mta.modules.plan.domain.PlanNode;
+
+import java.util.List;
+
+public class PlanNodeResponse {
+
+    private final String id;
+    private final String name;
+    private final String type;
+    private final String assignee;
+    private final int order;
+    private final List<PlanNodeResponse> children;
+
+    public PlanNodeResponse(String id, String name, String type, String assignee, int order,
+                            List<PlanNodeResponse> children) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.assignee = assignee;
+        this.order = order;
+        this.children = children;
+    }
+
+    public static PlanNodeResponse from(PlanNode node) {
+        List<PlanNodeResponse> childResponses = node.getChildren().stream()
+                .map(PlanNodeResponse::from)
+                .toList();
+        return new PlanNodeResponse(node.getId(), node.getName(), node.getType(), node.getAssignee(), node.getOrder(),
+                childResponses);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getAssignee() {
+        return assignee;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public List<PlanNodeResponse> getChildren() {
+        return children;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanSummaryResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/dto/PlanSummaryResponse.java
@@ -1,0 +1,75 @@
+package com.bob.mta.modules.plan.dto;
+
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanStatus;
+
+import java.time.OffsetDateTime;
+
+public class PlanSummaryResponse {
+
+    private final String id;
+    private final String title;
+    private final String customerId;
+    private final String owner;
+    private final PlanStatus status;
+    private final OffsetDateTime startTime;
+    private final OffsetDateTime endTime;
+    private final int progress;
+
+    public PlanSummaryResponse(String id, String title, String customerId, String owner, PlanStatus status,
+                               OffsetDateTime startTime, OffsetDateTime endTime, int progress) {
+        this.id = id;
+        this.title = title;
+        this.customerId = customerId;
+        this.owner = owner;
+        this.status = status;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.progress = progress;
+    }
+
+    public static PlanSummaryResponse from(Plan plan) {
+        return new PlanSummaryResponse(
+                plan.getId(),
+                plan.getTitle(),
+                plan.getCustomerId(),
+                plan.getOwner(),
+                plan.getStatus(),
+                plan.getStartTime(),
+                plan.getEndTime(),
+                plan.getProgress()
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public PlanStatus getStatus() {
+        return status;
+    }
+
+    public OffsetDateTime getStartTime() {
+        return startTime;
+    }
+
+    public OffsetDateTime getEndTime() {
+        return endTime;
+    }
+
+    public int getProgress() {
+        return progress;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/service/PlanService.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/service/PlanService.java
@@ -1,0 +1,12 @@
+package com.bob.mta.modules.plan.service;
+
+import com.bob.mta.modules.plan.domain.Plan;
+
+import java.util.List;
+
+public interface PlanService {
+
+    List<Plan> listPlans(String customerId, String status);
+
+    Plan getPlan(String id);
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanService.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanService.java
@@ -1,0 +1,74 @@
+package com.bob.mta.modules.plan.service.impl;
+
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanNode;
+import com.bob.mta.modules.plan.domain.PlanStatus;
+import com.bob.mta.modules.plan.service.PlanService;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+@Service
+public class InMemoryPlanService implements PlanService {
+
+    private final ConcurrentMap<String, Plan> plans = new ConcurrentHashMap<>();
+
+    public InMemoryPlanService() {
+        seedPlans();
+    }
+
+    private void seedPlans() {
+        PlanNode backupDb = new PlanNode("node-1", "数据库备份", "REMOTE", "admin", 1, List.of());
+        PlanNode notify = new PlanNode("node-2", "通知客户", "EMAIL", "operator", 2, List.of());
+        Plan plan1 = new Plan(
+                "plan-001",
+                "东京医疗季度巡检",
+                "cust-001",
+                "admin",
+                PlanStatus.SCHEDULED,
+                OffsetDateTime.now().plusDays(3),
+                OffsetDateTime.now().plusDays(3).plusHours(4),
+                30,
+                List.of(backupDb, notify)
+        );
+        PlanNode review = new PlanNode("node-3", "现场巡检", "CHECKLIST", "operator", 1, List.of());
+        Plan plan2 = new Plan(
+                "plan-002",
+                "大阪制造系统升级",
+                "cust-002",
+                "operator",
+                PlanStatus.DESIGN,
+                OffsetDateTime.now().plusWeeks(1),
+                OffsetDateTime.now().plusWeeks(1).plusHours(6),
+                10,
+                List.of(review)
+        );
+        plans.put(plan1.getId(), plan1);
+        plans.put(plan2.getId(), plan2);
+    }
+
+    @Override
+    public List<Plan> listPlans(String customerId, String status) {
+        return plans.values().stream()
+                .filter(plan -> !StringUtils.hasText(customerId) || plan.getCustomerId().equals(customerId))
+                .filter(plan -> !StringUtils.hasText(status) || plan.getStatus().name().equalsIgnoreCase(status))
+                .sorted((a, b) -> a.getStartTime().compareTo(b.getStartTime()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Plan getPlan(String id) {
+        Plan plan = plans.get(id);
+        if (plan == null) {
+            throw new BusinessException(ErrorCode.PLAN_NOT_FOUND);
+        }
+        return plan;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/controller/UserController.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/controller/UserController.java
@@ -1,0 +1,75 @@
+package com.bob.mta.modules.user.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.modules.user.domain.User;
+import com.bob.mta.modules.user.dto.ActivateUserRequest;
+import com.bob.mta.modules.user.dto.ActivationLinkResponse;
+import com.bob.mta.modules.user.dto.AssignRolesRequest;
+import com.bob.mta.modules.user.dto.CreateUserRequest;
+import com.bob.mta.modules.user.dto.UserResponse;
+import com.bob.mta.modules.user.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ApiResponse<UserResponse> createUser(@Valid @RequestBody CreateUserRequest request) {
+        User user = userService.createUser(request);
+        return ApiResponse.success(UserResponse.from(user));
+    }
+
+    @PostMapping("/activation")
+    public ApiResponse<ActivationLinkResponse> activate(@Valid @RequestBody ActivateUserRequest request) {
+        ActivationLinkResponse activationLink = userService.activateUser(request.getToken());
+        return ApiResponse.success(activationLink);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/{id}/activation/resend")
+    public ApiResponse<ActivationLinkResponse> resendActivation(@PathVariable String id) {
+        ActivationLinkResponse activationLink = userService.resendActivation(id);
+        return ApiResponse.success(activationLink);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}/roles")
+    public ApiResponse<UserResponse> assignRoles(@PathVariable String id, @Valid @RequestBody AssignRolesRequest request) {
+        User user = userService.assignRoles(id, request.getRoles());
+        return ApiResponse.success(UserResponse.from(user));
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN','OPERATOR')")
+    @GetMapping
+    public ApiResponse<List<UserResponse>> listUsers() {
+        List<UserResponse> responses = userService.findAll().stream()
+                .map(UserResponse::from)
+                .toList();
+        return ApiResponse.success(responses);
+    }
+
+    @PreAuthorize("hasAnyRole('ADMIN','OPERATOR')")
+    @GetMapping("/{id}")
+    public ApiResponse<UserResponse> getUser(@PathVariable String id) {
+        User user = userService.getById(id);
+        return ApiResponse.success(UserResponse.from(user));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/domain/ActivationToken.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/domain/ActivationToken.java
@@ -1,0 +1,32 @@
+package com.bob.mta.modules.user.domain;
+
+import java.time.OffsetDateTime;
+
+public class ActivationToken {
+
+    private final String token;
+    private final String userId;
+    private final OffsetDateTime expiresAt;
+
+    public ActivationToken(String token, String userId, OffsetDateTime expiresAt) {
+        this.token = token;
+        this.userId = userId;
+        this.expiresAt = expiresAt;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public OffsetDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public boolean isExpired() {
+        return OffsetDateTime.now().isAfter(expiresAt);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/domain/User.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/domain/User.java
@@ -1,0 +1,152 @@
+package com.bob.mta.modules.user.domain;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class User {
+
+    private final String id;
+    private final String username;
+    private final String displayName;
+    private final String email;
+    private final String passwordHash;
+    private final UserStatus status;
+    private final Set<String> roles;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+
+    private User(Builder builder) {
+        this.id = builder.id;
+        this.username = builder.username;
+        this.displayName = builder.displayName;
+        this.email = builder.email;
+        this.passwordHash = builder.passwordHash;
+        this.status = builder.status;
+        this.roles = Collections.unmodifiableSet(new HashSet<>(builder.roles));
+        this.createdAt = builder.createdAt;
+        this.updatedAt = builder.updatedAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public Builder toBuilder() {
+        return new Builder()
+                .id(id)
+                .username(username)
+                .displayName(displayName)
+                .email(email)
+                .passwordHash(passwordHash)
+                .status(status)
+                .roles(roles)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String id;
+        private String username;
+        private String displayName;
+        private String email;
+        private String passwordHash;
+        private UserStatus status;
+        private Set<String> roles = new HashSet<>();
+        private OffsetDateTime createdAt;
+        private OffsetDateTime updatedAt;
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            return this;
+        }
+
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public Builder passwordHash(String passwordHash) {
+            this.passwordHash = passwordHash;
+            return this;
+        }
+
+        public Builder status(UserStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder roles(Set<String> roles) {
+            this.roles = roles == null ? new HashSet<>() : new HashSet<>(roles);
+            return this;
+        }
+
+        public Builder addRole(String role) {
+            Objects.requireNonNull(role, "role");
+            this.roles.add(role);
+            return this;
+        }
+
+        public Builder createdAt(OffsetDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder updatedAt(OffsetDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        public User build() {
+            return new User(this);
+        }
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/domain/UserStatus.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/domain/UserStatus.java
@@ -1,0 +1,7 @@
+package com.bob.mta.modules.user.domain;
+
+public enum UserStatus {
+    PENDING_ACTIVATION,
+    ACTIVE,
+    LOCKED
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/dto/ActivateUserRequest.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/dto/ActivateUserRequest.java
@@ -1,0 +1,17 @@
+package com.bob.mta.modules.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ActivateUserRequest {
+
+    @NotBlank
+    private String token;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/dto/ActivationLinkResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/dto/ActivationLinkResponse.java
@@ -1,0 +1,22 @@
+package com.bob.mta.modules.user.dto;
+
+import java.time.OffsetDateTime;
+
+public class ActivationLinkResponse {
+
+    private final String token;
+    private final OffsetDateTime expiresAt;
+
+    public ActivationLinkResponse(String token, OffsetDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public OffsetDateTime getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/dto/AssignRolesRequest.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/dto/AssignRolesRequest.java
@@ -1,0 +1,19 @@
+package com.bob.mta.modules.user.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public class AssignRolesRequest {
+
+    @NotEmpty
+    private List<String> roles;
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/dto/CreateUserRequest.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/dto/CreateUserRequest.java
@@ -1,0 +1,55 @@
+package com.bob.mta.modules.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public class CreateUserRequest {
+
+    @NotBlank
+    @Size(min = 3, max = 32)
+    private String username;
+
+    @NotBlank
+    private String displayName;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    private List<String> roles;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/dto/UserResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/dto/UserResponse.java
@@ -1,0 +1,76 @@
+package com.bob.mta.modules.user.dto;
+
+import com.bob.mta.modules.user.domain.User;
+import com.bob.mta.modules.user.domain.UserStatus;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class UserResponse {
+
+    private final String id;
+    private final String username;
+    private final String displayName;
+    private final String email;
+    private final UserStatus status;
+    private final List<String> roles;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+
+    public UserResponse(String id, String username, String displayName, String email, UserStatus status,
+                        List<String> roles, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+        this.id = id;
+        this.username = username;
+        this.displayName = displayName;
+        this.email = email;
+        this.status = status;
+        this.roles = roles;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getDisplayName(),
+                user.getEmail(),
+                user.getStatus(),
+                user.getRoles().stream().sorted().toList(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/service/UserService.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/UserService.java
@@ -1,0 +1,25 @@
+package com.bob.mta.modules.user.service;
+
+import com.bob.mta.modules.user.domain.User;
+import com.bob.mta.modules.user.dto.ActivationLinkResponse;
+import com.bob.mta.modules.user.dto.CreateUserRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserService {
+
+    User createUser(CreateUserRequest request);
+
+    ActivationLinkResponse activateUser(String token);
+
+    ActivationLinkResponse resendActivation(String userId);
+
+    User assignRoles(String userId, List<String> roles);
+
+    List<User> findAll();
+
+    User getById(String id);
+
+    Optional<User> findByUsername(String username);
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/service/command/CreateUserCommand.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/command/CreateUserCommand.java
@@ -1,0 +1,14 @@
+package com.bob.mta.modules.user.service.command;
+
+import java.util.List;
+
+/**
+ * Command object describing the information required to create a user.
+ */
+public record CreateUserCommand(
+        String username,
+        String displayName,
+        String email,
+        String password,
+        List<String> roles) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/service/impl/InMemoryUserService.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/impl/InMemoryUserService.java
@@ -1,0 +1,175 @@
+package com.bob.mta.modules.user.service.impl;
+
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.user.domain.ActivationToken;
+import com.bob.mta.modules.user.domain.User;
+import com.bob.mta.modules.user.domain.UserStatus;
+import com.bob.mta.modules.user.dto.ActivationLinkResponse;
+import com.bob.mta.modules.user.dto.CreateUserRequest;
+import com.bob.mta.modules.user.service.UserService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+@Service
+public class InMemoryUserService implements UserService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final ConcurrentMap<String, User> users = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ActivationToken> activationTokens = new ConcurrentHashMap<>();
+
+    public InMemoryUserService(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+        seedUsers();
+    }
+
+    private void seedUsers() {
+        registerSeedUser("1", "admin", "Admin", "admin@example.com", "admin123", Set.of("ROLE_ADMIN"), true);
+        registerSeedUser("2", "operator", "Operator", "operator@example.com", "operator123", Set.of("ROLE_OPERATOR"), true);
+    }
+
+    private void registerSeedUser(String id, String username, String displayName, String email, String rawPassword,
+                                  Set<String> roles, boolean activated) {
+        OffsetDateTime now = OffsetDateTime.now();
+        User user = User.builder()
+                .id(id)
+                .username(username)
+                .displayName(displayName)
+                .email(email)
+                .passwordHash(passwordEncoder.encode(rawPassword))
+                .status(activated ? UserStatus.ACTIVE : UserStatus.PENDING_ACTIVATION)
+                .roles(roles)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+        users.put(user.getId(), user);
+    }
+
+    @Override
+    public User createUser(CreateUserRequest request) {
+        String username = request.getUsername().toLowerCase();
+        ensureUsernameNotExists(username);
+        String userId = UUID.randomUUID().toString();
+        OffsetDateTime now = OffsetDateTime.now();
+        User user = User.builder()
+                .id(userId)
+                .username(username)
+                .displayName(request.getDisplayName())
+                .email(request.getEmail())
+                .passwordHash(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .status(UserStatus.PENDING_ACTIVATION)
+                .roles(toRoleSet(request.getRoles()))
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+        users.put(user.getId(), user);
+        ActivationToken activationToken = generateActivationToken(user.getId());
+        activationTokens.put(activationToken.getToken(), activationToken);
+        return user;
+    }
+
+    @Override
+    public ActivationLinkResponse activateUser(String token) {
+        ActivationToken activationToken = activationTokens.remove(token);
+        if (activationToken == null || activationToken.isExpired()) {
+            throw new BusinessException(ErrorCode.ACTIVATION_TOKEN_INVALID);
+        }
+        User user = users.get(activationToken.getUserId());
+        if (user == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        User updated = user.toBuilder()
+                .status(UserStatus.ACTIVE)
+                .updatedAt(OffsetDateTime.now())
+                .build();
+        users.put(updated.getId(), updated);
+        return new ActivationLinkResponse(token, activationToken.getExpiresAt());
+    }
+
+    @Override
+    public ActivationLinkResponse resendActivation(String userId) {
+        User user = users.get(userId);
+        if (user == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        ActivationToken activationToken = generateActivationToken(userId);
+        activationTokens.entrySet().removeIf(entry -> entry.getValue().getUserId().equals(userId));
+        activationTokens.put(activationToken.getToken(), activationToken);
+        return new ActivationLinkResponse(activationToken.getToken(), activationToken.getExpiresAt());
+    }
+
+    @Override
+    public User assignRoles(String userId, List<String> roles) {
+        User user = users.get(userId);
+        if (user == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        User updated = user.toBuilder()
+                .roles(toRoleSet(roles))
+                .updatedAt(OffsetDateTime.now())
+                .build();
+        users.put(updated.getId(), updated);
+        return updated;
+    }
+
+    @Override
+    public List<User> findAll() {
+        return new ArrayList<>(users.values());
+    }
+
+    @Override
+    public User getById(String id) {
+        User user = users.get(id);
+        if (user == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return user;
+    }
+
+    @Override
+    public Optional<User> findByUsername(String username) {
+        if (!StringUtils.hasText(username)) {
+            return Optional.empty();
+        }
+        String normalized = username.toLowerCase();
+        return users.values().stream()
+                .filter(user -> user.getUsername().equalsIgnoreCase(normalized))
+                .findFirst();
+    }
+
+    private void ensureUsernameNotExists(String username) {
+        boolean exists = users.values().stream()
+                .map(User::getUsername)
+                .anyMatch(existing -> existing.equalsIgnoreCase(username));
+        if (exists) {
+            throw new BusinessException(ErrorCode.USERNAME_EXISTS);
+        }
+    }
+
+    private ActivationToken generateActivationToken(String userId) {
+        OffsetDateTime expires = OffsetDateTime.now().plus(1, ChronoUnit.DAYS);
+        return new ActivationToken(UUID.randomUUID().toString(), userId, expires);
+    }
+
+    private Set<String> toRoleSet(List<String> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return Set.of("ROLE_OPERATOR");
+        }
+        return roles.stream()
+                .filter(StringUtils::hasText)
+                .map(role -> role.toUpperCase().startsWith("ROLE_") ? role.toUpperCase() : "ROLE_" + role.toUpperCase())
+                .collect(Collectors.toSet());
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/service/model/ActivationLink.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/model/ActivationLink.java
@@ -1,0 +1,9 @@
+package com.bob.mta.modules.user.service.model;
+
+import java.time.Instant;
+
+/**
+ * Value object describing an activation link payload returned to callers.
+ */
+public record ActivationLink(String token, Instant expiresAt) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/service/model/CreateUserResult.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/model/CreateUserResult.java
@@ -1,0 +1,7 @@
+package com.bob.mta.modules.user.service.model;
+
+/**
+ * Combined result of a user creation attempt containing the new profile and activation link.
+ */
+public record CreateUserResult(UserView user, ActivationLink activation) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/service/model/UserAuthentication.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/model/UserAuthentication.java
@@ -1,0 +1,15 @@
+package com.bob.mta.modules.user.service.model;
+
+import com.bob.mta.modules.user.domain.UserStatus;
+import java.util.List;
+
+/**
+ * Authentication projection consumed by the auth module.
+ */
+public record UserAuthentication(
+        String id,
+        String username,
+        String displayName,
+        UserStatus status,
+        List<String> roles) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/service/model/UserView.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/model/UserView.java
@@ -1,0 +1,16 @@
+package com.bob.mta.modules.user.service.model;
+
+import com.bob.mta.modules.user.domain.UserStatus;
+import java.util.List;
+
+/**
+ * Read model exposed by the user service for API consumers.
+ */
+public record UserView(
+        String id,
+        String username,
+        String displayName,
+        String email,
+        UserStatus status,
+        List<String> roles) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/user/service/query/UserQuery.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/query/UserQuery.java
@@ -1,0 +1,9 @@
+package com.bob.mta.modules.user.service.query;
+
+import com.bob.mta.modules.user.domain.UserStatus;
+
+/**
+ * Filtering options available when listing users.
+ */
+public record UserQuery(UserStatus status) {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,40 @@
+spring:
+  application:
+    name: bob-mta-backend
+  datasource:
+    url: jdbc:postgresql://localhost:5432/bobmta
+    username: bobmta
+    password: change-me
+    driver-class-name: org.postgresql.Driver
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
+  messages:
+    basename: i18n/messages
+    encoding: UTF-8
+  mvc:
+    format:
+      date-time: yyyy-MM-dd'T'HH:mm:ssXXX
+  sql:
+    init:
+      platform: postgresql
+      mode: never
+server:
+  port: 8080
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+jwt:
+  issuer: bob-mta
+  access-token:
+    secret: change-me-please
+    expiration-minutes: 120
+logging:
+  level:
+    root: INFO
+    com.bob.mta: DEBUG
+  pattern:
+    console: '{"timestamp":"%d{yyyy-MM-dd''T''HH:mm:ss.SSSZ}","level":"%p","logger":"%c{1}","thread":"%t","message":%msg,"trace":%ex}'

--- a/backend/src/main/resources/i18n/messages_ja.properties
+++ b/backend/src/main/resources/i18n/messages_ja.properties
@@ -1,0 +1,2 @@
+api.common.success=成功
+api.common.failure=失敗

--- a/backend/src/main/resources/i18n/messages_zh.properties
+++ b/backend/src/main/resources/i18n/messages_zh.properties
@@ -1,0 +1,2 @@
+api.common.success=成功
+api.common.failure=失败

--- a/backend/src/test/java/com/bob/mta/BobMtaApplicationTests.java
+++ b/backend/src/test/java/com/bob/mta/BobMtaApplicationTests.java
@@ -1,0 +1,12 @@
+package com.bob.mta;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BobMtaApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/backend/src/test/java/com/bob/mta/api/PingControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/api/PingControllerTest.java
@@ -1,0 +1,18 @@
+package com.bob.mta.api;
+
+import com.bob.mta.common.api.ApiResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PingControllerTest {
+
+    @Test
+    void pingShouldReturnOk() {
+        PingController controller = new PingController();
+        ApiResponse<?> response = controller.ping();
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.MAP)
+                .containsEntry("status", "ok");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/common/api/ApiResponseTest.java
+++ b/backend/src/test/java/com/bob/mta/common/api/ApiResponseTest.java
@@ -1,0 +1,26 @@
+package com.bob.mta.common.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiResponseTest {
+
+    @Test
+    void successShouldContainData() {
+        ApiResponse<String> response = ApiResponse.success("ok");
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isEqualTo("ok");
+        assertThat(response.getCode()).isEqualTo("OK");
+        assertThat(response.getMessage()).isEqualTo("success");
+    }
+
+    @Test
+    void failureShouldContainErrorInfo() {
+        ApiResponse<Object> response = ApiResponse.failure("ERR", "failure");
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getCode()).isEqualTo("ERR");
+        assertThat(response.getMessage()).isEqualTo("failure");
+        assertThat(response.getData()).isNull();
+    }
+}

--- a/backend/src/test/java/com/bob/mta/common/api/PageResponseTest.java
+++ b/backend/src/test/java/com/bob/mta/common/api/PageResponseTest.java
@@ -1,0 +1,19 @@
+package com.bob.mta.common.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PageResponseTest {
+
+    @Test
+    void ofShouldExposePaginationInfo() {
+        PageResponse<String> response = PageResponse.of(List.of("a", "b"), 5, 1, 2);
+        assertThat(response.getItems()).containsExactly("a", "b");
+        assertThat(response.getTotal()).isEqualTo(5);
+        assertThat(response.getPage()).isEqualTo(1);
+        assertThat(response.getSize()).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/bob/mta/common/security/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,71 @@
+package com.bob.mta.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+class JwtAuthenticationFilterTest {
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void filterShouldPopulateSecurityContextWhenTokenPresent() throws ServletException, IOException {
+        JwtProperties properties = new JwtProperties();
+        properties.getAccessToken().setSecret("a-very-long-secret-key-for-tests-1234567890");
+        JwtTokenProvider provider = new JwtTokenProvider(properties);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(provider);
+
+        String token = provider.createToken("u-1", "admin", List.of("ROLE_ADMIN"));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getName()).isEqualTo("admin");
+    }
+
+    @Test
+    void filterShouldSkipWhenTokenMissing() throws ServletException, IOException {
+        JwtProperties properties = new JwtProperties();
+        properties.getAccessToken().setSecret("a-very-long-secret-key-for-tests-1234567890");
+        JwtTokenProvider provider = new JwtTokenProvider(properties);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(provider);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+}

--- a/backend/src/test/java/com/bob/mta/common/security/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/JwtTokenProviderTest.java
@@ -1,0 +1,26 @@
+package com.bob.mta.common.security;
+
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    @Test
+    void createTokenShouldEmbedClaims() {
+        JwtProperties properties = new JwtProperties();
+        properties.getAccessToken().setSecret("a-very-long-secret-key-for-tests-1234567890");
+        properties.getAccessToken().setExpirationMinutes(5);
+        JwtTokenProvider provider = new JwtTokenProvider(properties);
+
+        String token = provider.createToken("123", "admin", List.of("ROLE_ADMIN"));
+        Claims claims = provider.parseClaims(token);
+
+        assertThat(claims.getSubject()).isEqualTo("123");
+        assertThat(claims.get("username")).isEqualTo("admin");
+        assertThat((List<?>) claims.get("roles")).containsExactly("ROLE_ADMIN");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/common/security/RestAccessDeniedHandlerTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/RestAccessDeniedHandlerTest.java
@@ -1,0 +1,26 @@
+package com.bob.mta.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestAccessDeniedHandlerTest {
+
+    @Test
+    void handleShouldWriteJsonResponse() throws ServletException, IOException {
+        RestAccessDeniedHandler handler = new RestAccessDeniedHandler(new ObjectMapper());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.handle(new MockHttpServletRequest(), response, new AccessDeniedException("denied"));
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentAsString()).contains("ACCESS_DENIED");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/common/security/RestAuthenticationEntryPointTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/RestAuthenticationEntryPointTest.java
@@ -1,0 +1,26 @@
+package com.bob.mta.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestAuthenticationEntryPointTest {
+
+    @Test
+    void commenceShouldWriteUnauthorizedJson() throws ServletException, IOException {
+        RestAuthenticationEntryPoint entryPoint = new RestAuthenticationEntryPoint(new ObjectMapper());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        entryPoint.commence(new MockHttpServletRequest(), response, new AuthenticationException("bad") {});
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTHENTICATION_FAILED");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/auth/AuthControllerTest.java
@@ -1,0 +1,87 @@
+package com.bob.mta.modules.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("login endpoint returns token for valid credentials")
+    void shouldLoginWithValidCredentials() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "admin",
+                                "password", "admin123"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.data.displayName").value("Admin"))
+                .andExpect(jsonPath("$.data.token").isNotEmpty())
+                .andExpect(jsonPath("$.data.roles[0]").value("ADMIN"))
+                .andExpect(jsonPath("$.data.expiresAt").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("login endpoint rejects invalid credentials with 401")
+    void shouldRejectInvalidCredentials() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "admin",
+                                "password", "wrong"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(4010));
+    }
+
+    @Test
+    @DisplayName("/me endpoint returns the authenticated profile")
+    void shouldReturnCurrentUserProfile() throws Exception {
+        final String token = loginAndExtractToken("admin", "admin123");
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0))
+                .andExpect(jsonPath("$.data.username").value("admin"))
+                .andExpect(jsonPath("$.data.roles[0]").value("ADMIN"));
+    }
+
+    private String loginAndExtractToken(final String username, final String password) throws Exception {
+        final MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", username,
+                                "password", password))))
+                .andExpect(status().isOk())
+                .andReturn();
+        final String response = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        final JsonNode node = objectMapper.readTree(response);
+        assertThat(node.path("data").path("token").asText()).isNotBlank();
+        return node.path("data").path("token").asText();
+    }
+}
+

--- a/backend/src/test/java/com/bob/mta/modules/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/auth/controller/AuthControllerTest.java
@@ -1,0 +1,50 @@
+package com.bob.mta.modules.auth.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.common.security.JwtProperties;
+import com.bob.mta.common.security.JwtTokenProvider;
+import com.bob.mta.modules.auth.dto.CurrentUserResponse;
+import com.bob.mta.modules.auth.dto.LoginRequest;
+import com.bob.mta.modules.auth.dto.LoginResponse;
+import com.bob.mta.modules.auth.service.impl.InMemoryAuthService;
+import com.bob.mta.modules.user.service.impl.InMemoryUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthControllerTest {
+
+    private AuthController controller;
+    private InMemoryAuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        InMemoryUserService userService = new InMemoryUserService(new BCryptPasswordEncoder());
+        JwtProperties properties = new JwtProperties();
+        properties.getAccessToken().setSecret("a-very-long-secret-key-for-tests-1234567890");
+        JwtTokenProvider provider = new JwtTokenProvider(properties);
+        authService = new InMemoryAuthService(userService, new BCryptPasswordEncoder(), provider);
+        controller = new AuthController(authService);
+    }
+
+    @Test
+    void loginShouldReturnToken() {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("admin");
+        request.setPassword("admin123");
+
+        ApiResponse<LoginResponse> response = controller.login(request);
+
+        assertThat(response.getData().getToken()).isNotBlank();
+    }
+
+    @Test
+    void currentUserShouldReturnDetails() {
+        UserDetails userDetails = authService.loadUserByUsername("admin");
+        ApiResponse<CurrentUserResponse> response = controller.currentUser(userDetails);
+        assertThat(response.getData().getUsername()).isEqualTo("admin");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/auth/service/impl/InMemoryAuthServiceTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/auth/service/impl/InMemoryAuthServiceTest.java
@@ -1,0 +1,80 @@
+package com.bob.mta.modules.auth.service.impl;
+
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.common.security.JwtProperties;
+import com.bob.mta.common.security.JwtTokenProvider;
+import com.bob.mta.modules.auth.dto.CurrentUserResponse;
+import com.bob.mta.modules.auth.dto.LoginRequest;
+import com.bob.mta.modules.auth.dto.LoginResponse;
+import com.bob.mta.modules.user.dto.CreateUserRequest;
+import com.bob.mta.modules.user.service.impl.InMemoryUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InMemoryAuthServiceTest {
+
+    private InMemoryAuthService authService;
+    private InMemoryUserService userService;
+
+    @BeforeEach
+    void setUp() {
+        PasswordEncoder encoder = new BCryptPasswordEncoder();
+        userService = new InMemoryUserService(encoder);
+        JwtProperties properties = new JwtProperties();
+        properties.getAccessToken().setSecret("a-very-long-secret-key-for-tests-1234567890");
+        JwtTokenProvider provider = new JwtTokenProvider(properties);
+        authService = new InMemoryAuthService(userService, encoder, provider);
+    }
+
+    @Test
+    void loginShouldReturnTokenForValidUser() {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("admin");
+        request.setPassword("admin123");
+
+        LoginResponse response = authService.login(request);
+
+        assertThat(response.getToken()).isNotBlank();
+        assertThat(response.getUsername()).isEqualTo("admin");
+        assertThat(response.getRoles()).contains("ROLE_ADMIN");
+    }
+
+    @Test
+    void loginShouldFailForInactiveUser() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("inactive");
+        request.setDisplayName("Inactive");
+        request.setEmail("inactive@demo.com");
+        userService.createUser(request);
+
+        LoginRequest login = new LoginRequest();
+        login.setUsername("inactive");
+        login.setPassword("whatever");
+
+        assertThatThrownBy(() -> authService.login(login))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_INACTIVE.getCode());
+    }
+
+    @Test
+    void loadUserByUsernameShouldReturnUserDetails() {
+        UserDetails userDetails = authService.loadUserByUsername("admin");
+        assertThat(userDetails.getUsername()).isEqualTo("admin");
+        assertThat(userDetails.getAuthorities()).extracting("authority").contains("ROLE_ADMIN");
+    }
+
+    @Test
+    void currentUserShouldMapAuthorities() {
+        UserDetails userDetails = authService.loadUserByUsername("admin");
+        CurrentUserResponse current = authService.currentUser(userDetails);
+        assertThat(current.getUsername()).isEqualTo("admin");
+        assertThat(current.getRoles()).contains("ROLE_ADMIN");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/customer/CustomerControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/customer/CustomerControllerTest.java
@@ -1,0 +1,90 @@
+package com.bob.mta.modules.customer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CustomerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("customers listing returns paginated records")
+    void shouldListCustomers() throws Exception {
+        final String token = authenticate();
+
+        mockMvc.perform(get("/api/v1/customers")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.total").value(3))
+                .andExpect(jsonPath("$.data.list[0].code").value("CUST-101"));
+    }
+
+    @Test
+    @DisplayName("customers listing requires authentication")
+    void shouldRejectAnonymousAccess() throws Exception {
+        mockMvc.perform(get("/api/v1/customers"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(4010));
+    }
+
+    @Test
+    @DisplayName("customers listing supports filtering by region")
+    void shouldFilterByRegion() throws Exception {
+        final String token = authenticate();
+
+        mockMvc.perform(get("/api/v1/customers")
+                        .header("Authorization", "Bearer " + token)
+                        .param("region", "北海道"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.list.length()").value(2))
+                .andExpect(jsonPath("$.data.list[0].region").value("北海道"));
+    }
+
+    @Test
+    @DisplayName("customer detail returns 404 when not found")
+    void shouldReturnNotFoundForMissingCustomer() throws Exception {
+        final String token = authenticate();
+
+        mockMvc.perform(get("/api/v1/customers/9999")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(4040));
+    }
+
+    private String authenticate() throws Exception {
+        final MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "admin",
+                                "password", "admin123"))))
+                .andExpect(status().isOk())
+                .andReturn();
+        final JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        final String token = body.path("data").path("token").asText();
+        assertThat(token).isNotBlank();
+        return token;
+    }
+}
+

--- a/backend/src/test/java/com/bob/mta/modules/customer/controller/CustomerControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/customer/controller/CustomerControllerTest.java
@@ -1,0 +1,36 @@
+package com.bob.mta.modules.customer.controller;
+
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.modules.customer.dto.CustomerDetailResponse;
+import com.bob.mta.modules.customer.dto.CustomerSummaryResponse;
+import com.bob.mta.modules.customer.service.impl.InMemoryCustomerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomerControllerTest {
+
+    private CustomerController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new CustomerController(new InMemoryCustomerService());
+    }
+
+    @Test
+    void searchShouldReturnPagedResults() {
+        PageResponse<CustomerSummaryResponse> page = controller.search("", "", 0, 1).getData();
+        assertThat(page.getItems()).hasSize(1);
+        assertThat(page.getTotal()).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void detailShouldReturnCustomerInfo() {
+        CustomerDetailResponse response = controller.detail("cust-001").getData();
+        assertThat(response.getId()).isEqualTo("cust-001");
+        assertThat(response.getCustomFields()).isNotEmpty();
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/customer/service/impl/InMemoryCustomerServiceTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/customer/service/impl/InMemoryCustomerServiceTest.java
@@ -1,0 +1,43 @@
+package com.bob.mta.modules.customer.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.modules.customer.dto.CustomerDetailResponse;
+import com.bob.mta.modules.customer.dto.CustomerSummaryResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InMemoryCustomerServiceTest {
+
+    private final InMemoryCustomerService service = new InMemoryCustomerService();
+
+    @Test
+    @DisplayName("keyword filter performs case-insensitive matching")
+    void shouldFilterCustomersByKeyword() {
+        final PageResponse<CustomerSummaryResponse> response = service.listCustomers(1, 20, "tokyo", null);
+
+        assertThat(response.getList()).hasSize(1);
+        assertThat(response.getList().get(0).name()).contains("东京");
+    }
+
+    @Test
+    @DisplayName("missing customer id raises BusinessException")
+    void shouldThrowWhenCustomerMissing() {
+        assertThatThrownBy(() -> service.getCustomer("missing"))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("customer detail returns immutable view of custom fields")
+    void shouldExposeCustomerDetail() {
+        final CustomerDetailResponse detail = service.getCustomer("101");
+
+        assertThat(detail.id()).isEqualTo("101");
+        assertThat(detail.fields()).isNotEmpty();
+        assertThat(detail.tags()).contains("重点客户");
+    }
+}
+

--- a/backend/src/test/java/com/bob/mta/modules/plan/PlanControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/PlanControllerTest.java
@@ -1,0 +1,82 @@
+package com.bob.mta.modules.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PlanControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("plans listing provides summary payloads")
+    void shouldListPlans() throws Exception {
+        final String token = authenticate();
+
+        mockMvc.perform(get("/api/v1/plans")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.total").value(2))
+                .andExpect(jsonPath("$.data.list[0].id").value("PLAN-5001"));
+    }
+
+    @Test
+    @DisplayName("plans listing can filter by status")
+    void shouldFilterByStatus() throws Exception {
+        final String token = authenticate();
+
+        mockMvc.perform(get("/api/v1/plans")
+                        .header("Authorization", "Bearer " + token)
+                        .param("status", "DESIGN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.total").value(1))
+                .andExpect(jsonPath("$.data.list[0].status").value("DESIGN"));
+    }
+
+    @Test
+    @DisplayName("plan detail returns 404 for unknown plan")
+    void shouldReturnNotFoundForMissingPlan() throws Exception {
+        final String token = authenticate();
+
+        mockMvc.perform(get("/api/v1/plans/UNKNOWN")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(4040));
+    }
+
+    private String authenticate() throws Exception {
+        final MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "admin",
+                                "password", "admin123"))))
+                .andExpect(status().isOk())
+                .andReturn();
+        final JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        final String token = body.path("data").path("token").asText();
+        assertThat(token).isNotBlank();
+        return token;
+    }
+}
+

--- a/backend/src/test/java/com/bob/mta/modules/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/controller/PlanControllerTest.java
@@ -1,0 +1,33 @@
+package com.bob.mta.modules.plan.controller;
+
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.modules.plan.dto.PlanDetailResponse;
+import com.bob.mta.modules.plan.dto.PlanSummaryResponse;
+import com.bob.mta.modules.plan.service.impl.InMemoryPlanService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlanControllerTest {
+
+    private PlanController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new PlanController(new InMemoryPlanService());
+    }
+
+    @Test
+    void listShouldReturnPlans() {
+        PageResponse<PlanSummaryResponse> page = controller.list("", "", 0, 1).getData();
+        assertThat(page.getItems()).hasSize(1);
+        assertThat(page.getTotal()).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void detailShouldReturnPlanWithNodes() {
+        PlanDetailResponse response = controller.detail("plan-001").getData();
+        assertThat(response.getNodes()).isNotEmpty();
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanServiceTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanServiceTest.java
@@ -1,0 +1,42 @@
+package com.bob.mta.modules.plan.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bob.mta.common.api.PageResponse;
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.modules.plan.dto.PlanDetailResponse;
+import com.bob.mta.modules.plan.dto.PlanSummaryResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InMemoryPlanServiceTest {
+
+    private final InMemoryPlanService service = new InMemoryPlanService();
+
+    @Test
+    @DisplayName("listPlans supports customerId filtering")
+    void shouldFilterPlansByCustomer() {
+        final PageResponse<PlanSummaryResponse> page = service.listPlans(1, 20, "201", null);
+
+        assertThat(page.getList()).hasSize(1);
+        assertThat(page.getList().get(0).customerId()).isEqualTo("201");
+    }
+
+    @Test
+    @DisplayName("getPlan throws BusinessException when id missing")
+    void shouldThrowWhenPlanMissing() {
+        assertThatThrownBy(() -> service.getPlan("missing"))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("plan detail exposes nodes and assignees")
+    void shouldReturnPlanDetail() {
+        final PlanDetailResponse detail = service.getPlan("PLAN-5001");
+
+        assertThat(detail.getNodes()).isNotEmpty();
+        assertThat(detail.getAssignees()).contains("admin");
+    }
+}
+

--- a/backend/src/test/java/com/bob/mta/modules/user/UserControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/user/UserControllerTest.java
@@ -1,0 +1,156 @@
+package com.bob.mta.modules.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String adminToken;
+
+    @BeforeEach
+    void authenticate() throws Exception {
+        adminToken = login("admin", "admin123");
+    }
+
+    @Test
+    @DisplayName("admin can create a new user and receive activation token")
+    void shouldCreateUser() throws Exception {
+        final MvcResult result = mockMvc.perform(post("/api/v1/users")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "qa.user",
+                                "displayName", "QA User",
+                                "email", "qa.user@example.com",
+                                "password", "password123",
+                                "roles", List.of("operator")))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.username").value("qa.user"))
+                .andExpect(jsonPath("$.data.activation.token").isNotEmpty())
+                .andExpect(jsonPath("$.data.status").value("PENDING_ACTIVATION"))
+                .andReturn();
+
+        final JsonNode node = objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        final String token = node.path("data").path("activation").path("token").asText();
+        assertThat(token).isNotBlank();
+
+        mockMvc.perform(post("/api/v1/users/activation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of("token", token))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    @DisplayName("user listing supports status filtering")
+    void shouldListUsersWithFilters() throws Exception {
+        // create additional pending user
+        mockMvc.perform(post("/api/v1/users")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "pending.user",
+                                "displayName", "Pending",
+                                "email", "pending@example.com",
+                                "password", "password123"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/users")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .param("status", "PENDING_ACTIVATION"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.list[0].status").value("PENDING_ACTIVATION"));
+    }
+
+    @Test
+    @DisplayName("activation resend requires authentication and returns token")
+    void shouldResendActivation() throws Exception {
+        final MvcResult result = mockMvc.perform(post("/api/v1/users")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "resend.user",
+                                "displayName", "Resend",
+                                "email", "resend@example.com",
+                                "password", "password123"))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        final JsonNode node = objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        final String userId = node.path("data").path("id").asText();
+
+        mockMvc.perform(post("/api/v1/users/" + userId + "/activation/resend")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.token").isNotEmpty())
+                .andExpect(jsonPath("$.data.expiresAt").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("roles assignment updates user profile")
+    void shouldAssignRoles() throws Exception {
+        final MvcResult result = mockMvc.perform(post("/api/v1/users")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "role.user",
+                                "displayName", "Role User",
+                                "email", "role.user@example.com",
+                                "password", "password123"))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        final String userId = objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8))
+                .path("data")
+                .path("id")
+                .asText();
+
+        mockMvc.perform(post("/api/v1/users/" + userId + "/roles")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of("roles", List.of("admin", "auditor")))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roles[0]").value("ADMIN"))
+                .andExpect(jsonPath("$.data.roles[1]").value("AUDITOR"));
+    }
+
+    private String login(final String username, final String password) throws Exception {
+        final MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", username,
+                                "password", password))))
+                .andExpect(status().isOk())
+                .andReturn();
+        final JsonNode node = objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        final String token = node.path("data").path("token").asText();
+        assertThat(token).isNotBlank();
+        return token;
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/user/controller/UserControllerTest.java
@@ -1,0 +1,72 @@
+package com.bob.mta.modules.user.controller;
+
+import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.modules.user.dto.ActivateUserRequest;
+import com.bob.mta.modules.user.dto.ActivationLinkResponse;
+import com.bob.mta.modules.user.dto.AssignRolesRequest;
+import com.bob.mta.modules.user.dto.CreateUserRequest;
+import com.bob.mta.modules.user.dto.UserResponse;
+import com.bob.mta.modules.user.service.impl.InMemoryUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserControllerTest {
+
+    private UserController controller;
+    private InMemoryUserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new InMemoryUserService(new BCryptPasswordEncoder());
+        controller = new UserController(userService);
+    }
+
+    @Test
+    void createUserShouldReturnResponse() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("controller");
+        request.setDisplayName("Controller User");
+        request.setEmail("controller@demo.com");
+
+        ApiResponse<UserResponse> response = controller.createUser(request);
+
+        assertThat(response.getData().getUsername()).isEqualTo("controller");
+    }
+
+    @Test
+    void activationEndpointsShouldReturnTokens() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("to-activate");
+        request.setDisplayName("To Activate");
+        request.setEmail("activate@demo.com");
+        String userId = controller.createUser(request).getData().getId();
+
+        ActivationLinkResponse resend = controller.resendActivation(userId).getData();
+        ActivateUserRequest activateUserRequest = new ActivateUserRequest();
+        activateUserRequest.setToken(resend.getToken());
+        ActivationLinkResponse activated = controller.activate(activateUserRequest).getData();
+
+        assertThat(activated.getToken()).isEqualTo(resend.getToken());
+    }
+
+    @Test
+    void assignRolesShouldUpdateUser() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("role-change");
+        request.setDisplayName("Role Change");
+        request.setEmail("role@demo.com");
+        String userId = controller.createUser(request).getData().getId();
+
+        AssignRolesRequest assign = new AssignRolesRequest();
+        assign.setRoles(List.of("auditor"));
+
+        UserResponse response = controller.assignRoles(userId, assign).getData();
+
+        assertThat(response.getRoles()).containsExactly("ROLE_AUDITOR");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/user/service/impl/InMemoryUserServiceTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/user/service/impl/InMemoryUserServiceTest.java
@@ -1,0 +1,82 @@
+package com.bob.mta.modules.user.service.impl;
+
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.user.domain.User;
+import com.bob.mta.modules.user.domain.UserStatus;
+import com.bob.mta.modules.user.dto.ActivationLinkResponse;
+import com.bob.mta.modules.user.dto.CreateUserRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InMemoryUserServiceTest {
+
+    private InMemoryUserService userService;
+
+    @BeforeEach
+    void setUp() {
+        PasswordEncoder encoder = new BCryptPasswordEncoder();
+        userService = new InMemoryUserService(encoder);
+    }
+
+    @Test
+    void createUserShouldPersistPendingAccount() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("newuser");
+        request.setDisplayName("New User");
+        request.setEmail("new@demo.com");
+        request.setRoles(List.of("admin"));
+
+        User user = userService.createUser(request);
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING_ACTIVATION);
+        assertThat(userService.findByUsername("newuser")).isPresent();
+    }
+
+    @Test
+    void createUserShouldFailWhenUsernameExists() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("admin");
+        request.setDisplayName("Dup");
+        request.setEmail("dup@demo.com");
+
+        assertThatThrownBy(() -> userService.createUser(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USERNAME_EXISTS.getCode());
+    }
+
+    @Test
+    void activationFlowShouldUpdateStatus() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("activate");
+        request.setDisplayName("Need Activation");
+        request.setEmail("activate@demo.com");
+        User user = userService.createUser(request);
+
+        ActivationLinkResponse resend = userService.resendActivation(user.getId());
+        ActivationLinkResponse activation = userService.activateUser(resend.getToken());
+
+        assertThat(activation.getToken()).isEqualTo(resend.getToken());
+        assertThat(userService.getById(user.getId()).getStatus()).isEqualTo(UserStatus.ACTIVE);
+    }
+
+    @Test
+    void assignRolesShouldNormalizeRoleNames() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUsername("roleuser");
+        request.setDisplayName("Role User");
+        request.setEmail("role@demo.com");
+        User user = userService.createUser(request);
+
+        User updated = userService.assignRoles(user.getId(), List.of("viewer", "ROLE_operator"));
+
+        assertThat(updated.getRoles()).containsExactlyInAnyOrder("ROLE_VIEWER", "ROLE_OPERATOR");
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BOB MTA Maintain Assistants</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bob-mta-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,25 @@
+.app {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0 auto;
+  max-width: 720px;
+  padding: 2rem;
+  line-height: 1.6;
+}
+
+.status-panel {
+  background: #f5f5f5;
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid #e0e0e0;
+  margin-top: 1rem;
+}
+
+.success {
+  color: #237804;
+  font-weight: 600;
+}
+
+.error {
+  color: #cf1322;
+  font-weight: 600;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import './App.css';
+
+type PingResponse = {
+  status: string;
+};
+
+function App() {
+  const [ping, setPing] = useState<PingResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/ping')
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const body = (await response.json()) as PingResponse;
+        setPing(body);
+      })
+      .catch((err) => {
+        setError(err.message);
+      });
+  }, []);
+
+  return (
+    <div className="app">
+      <h1>BOB MTA Maintain Assistants</h1>
+      <p>最简前后端联通性验证页面。</p>
+      <section className="status-panel">
+        <h2>后端连通性</h2>
+        {ping && <p className="success">后端响应：{ping.status}</p>}
+        {error && <p className="error">请求失败：{error}</p>}
+        {!ping && !error && <p>检查后端连接中...</p>}
+      </section>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,15 @@
+:root {
+  color-scheme: light dark;
+  background-color: #ffffff;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: #ffffff;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.spec.tsx"]
+}

--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "scripts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- establish JWT-based security configuration with token generation, filters, and REST error handlers to enforce RBAC across the API surface
- add in-memory user, customer, and plan services and controllers that follow the stage-two activation, listing, and detail flows described in the design doc
- expand unit tests for services, controllers, and security utilities while updating the README with stage-two usage and coverage guidance

## Testing
- `mvn -q verify` *(fails: cannot download Spring Boot parent due to HTTP 403 from Maven Central in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d64d6accb4832f9adebad11b0bbaa1