### PR TITLE
Implement user management workflows and refresh tests

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/user/controller/UserController.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/controller/UserController.java
@@ -1,12 +1,29 @@
 package com.bob.mta.modules.user.controller;
 
 import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.modules.user.domain.UserStatus;
+import com.bob.mta.modules.user.dto.ActivateUserRequest;
+import com.bob.mta.modules.user.dto.ActivationLinkResponse;
+import com.bob.mta.modules.user.dto.AssignRolesRequest;
+import com.bob.mta.modules.user.dto.CreateUserRequest;
 import com.bob.mta.modules.user.dto.UserResponse;
 import com.bob.mta.modules.user.service.UserService;
+import com.bob.mta.modules.user.service.command.CreateUserCommand;
+import com.bob.mta.modules.user.service.model.ActivationLink;
+import com.bob.mta.modules.user.service.model.CreateUserResult;
+import com.bob.mta.modules.user.service.model.UserView;
+import com.bob.mta.modules.user.service.query.UserQuery;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * REST controller exposing user and role management workflows.
@@ -21,5 +38,49 @@ public class UserController {
         this.userService = userService;
     }
 
-    // TODO: Implement user management endpoints
+    @GetMapping
+    public ApiResponse<List<UserResponse>> listUsers(@RequestParam(required = false) final UserStatus status) {
+        final List<UserResponse> users = userService.listUsers(new UserQuery(status)).stream()
+                .map(UserResponse::from)
+                .toList();
+        return ApiResponse.success(users);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<UserResponse> getUser(@PathVariable("id") final String id) {
+        final UserView user = userService.getUser(id);
+        return ApiResponse.success(UserResponse.from(user));
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<UserResponse> createUser(@Valid @RequestBody final CreateUserRequest request) {
+        final CreateUserCommand command = new CreateUserCommand(
+                request.getUsername(),
+                request.getDisplayName(),
+                request.getEmail(),
+                request.getPassword(),
+                request.getRoles());
+        final CreateUserResult result = userService.createUser(command);
+        return ApiResponse.success(UserResponse.from(result.user()));
+    }
+
+    @PostMapping(path = "/{id}/activation")
+    public ApiResponse<ActivationLinkResponse> resendActivation(@PathVariable("id") final String id) {
+        final ActivationLink activation = userService.resendActivation(id);
+        return ApiResponse.success(ActivationLinkResponse.from(activation));
+    }
+
+    @PostMapping(path = "/activation", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<UserResponse> activate(@Valid @RequestBody final ActivateUserRequest request) {
+        final UserView user = userService.activateUser(request.getToken());
+        return ApiResponse.success(UserResponse.from(user));
+    }
+
+    @PostMapping(path = "/{id}/roles", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<UserResponse> assignRoles(
+            @PathVariable("id") final String id,
+            @Valid @RequestBody final AssignRolesRequest request) {
+        final UserView user = userService.assignRoles(id, request.getRoles());
+        return ApiResponse.success(UserResponse.from(user));
+    }
 }

--- a/backend/src/main/java/com/bob/mta/modules/user/domain/User.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/domain/User.java
@@ -71,6 +71,11 @@ public class User {
         return activationToken;
     }
 
+    public void issueActivationToken(final ActivationToken token) {
+        this.activationToken = Objects.requireNonNull(token, "token");
+        markPendingActivation();
+    }
+
     public boolean passwordMatches(final String rawPassword) {
         return Objects.equals(password, rawPassword);
     }

--- a/backend/src/main/java/com/bob/mta/modules/user/dto/ActivationLinkResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/dto/ActivationLinkResponse.java
@@ -1,5 +1,7 @@
 package com.bob.mta.modules.user.dto;
 
+import com.bob.mta.modules.user.service.model.ActivationLink;
+
 import java.time.Instant;
 
 /**
@@ -22,5 +24,9 @@ public class ActivationLinkResponse {
 
     public Instant getExpiresAt() {
         return expiresAt;
+    }
+
+    public static ActivationLinkResponse from(final ActivationLink activationLink) {
+        return new ActivationLinkResponse(activationLink.token(), activationLink.expiresAt());
     }
 }

--- a/backend/src/main/java/com/bob/mta/modules/user/dto/UserResponse.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/dto/UserResponse.java
@@ -1,6 +1,7 @@
 package com.bob.mta.modules.user.dto;
 
 import com.bob.mta.modules.user.domain.UserStatus;
+import com.bob.mta.modules.user.service.model.UserView;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,5 +59,15 @@ public class UserResponse {
 
     public List<String> getRoles() {
         return new ArrayList<>(roles);
+    }
+
+    public static UserResponse from(final UserView user) {
+        return new UserResponse(
+                user.id(),
+                user.username(),
+                user.displayName(),
+                user.email(),
+                user.status(),
+                user.roles());
     }
 }

--- a/backend/src/main/java/com/bob/mta/modules/user/service/UserService.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/UserService.java
@@ -1,12 +1,30 @@
 package com.bob.mta.modules.user.service;
 
+import com.bob.mta.modules.user.service.command.CreateUserCommand;
+import com.bob.mta.modules.user.service.model.ActivationLink;
+import com.bob.mta.modules.user.service.model.CreateUserResult;
 import com.bob.mta.modules.user.service.model.UserAuthentication;
 import com.bob.mta.modules.user.service.model.UserView;
+import com.bob.mta.modules.user.service.query.UserQuery;
+
+import java.util.List;
 
 /**
  * Application service encapsulating user management workflows.
  */
 public interface UserService {
+
+    CreateUserResult createUser(CreateUserCommand command);
+
+    ActivationLink resendActivation(String userId);
+
+    UserView activateUser(String token);
+
+    UserView assignRoles(String userId, List<String> roles);
+
+    List<UserView> listUsers(UserQuery query);
+
+    UserView getUser(String userId);
 
     UserAuthentication authenticate(String username, String password);
 

--- a/backend/src/main/java/com/bob/mta/modules/user/service/impl/InMemoryUserService.java
+++ b/backend/src/main/java/com/bob/mta/modules/user/service/impl/InMemoryUserService.java
@@ -2,42 +2,265 @@ package com.bob.mta.modules.user.service.impl;
 
 import com.bob.mta.common.exception.BusinessException;
 import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.user.domain.ActivationToken;
+import com.bob.mta.modules.user.domain.User;
 import com.bob.mta.modules.user.domain.UserStatus;
 import com.bob.mta.modules.user.service.UserService;
+import com.bob.mta.modules.user.service.command.CreateUserCommand;
+import com.bob.mta.modules.user.service.model.ActivationLink;
+import com.bob.mta.modules.user.service.model.CreateUserResult;
 import com.bob.mta.modules.user.service.model.UserAuthentication;
 import com.bob.mta.modules.user.service.model.UserView;
-import java.util.List;
-import java.util.Map;
+import com.bob.mta.modules.user.service.query.UserQuery;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 /**
- * Simple in-memory implementation of UserService used during early development phases.
+ * Simple in-memory implementation of {@link UserService} used during early development phases.
  */
 @Service
 public class InMemoryUserService implements UserService {
 
-    private final Map<String, UserRecord> users = Map.of(
-            "admin", new UserRecord("1", "admin", "Admin", "admin@example.com", "admin123", List.of("ADMIN", "OPERATOR")),
-            "operator", new UserRecord("2", "operator", "Operator", "operator@example.com", "operator123", List.of("OPERATOR")));
+    private static final Duration DEFAULT_ACTIVATION_TTL = Duration.ofHours(24);
+
+    private final Map<String, User> usersById = new ConcurrentHashMap<>();
+    private final Map<String, User> usersByUsername = new ConcurrentHashMap<>();
+    private final AtomicLong idSequence = new AtomicLong();
+    private final Clock clock;
+    private final Duration activationTtl;
+
+    public InMemoryUserService() {
+        this(Clock.systemUTC(), DEFAULT_ACTIVATION_TTL);
+    }
+
+    public InMemoryUserService(final Clock clock) {
+        this(clock, DEFAULT_ACTIVATION_TTL);
+    }
+
+    public InMemoryUserService(final Clock clock, final Duration activationTtl) {
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.activationTtl = Objects.requireNonNull(activationTtl, "activationTtl");
+        seedDefaultUsers();
+    }
+
+    public void seedDefaultUsers() {
+        usersById.clear();
+        usersByUsername.clear();
+        idSequence.set(0);
+        registerActiveUser(nextId(), "admin", "系统管理员", "admin@example.com", "admin123",
+                List.of("ADMIN", "OPERATOR"));
+        registerActiveUser(nextId(), "operator", "运维专员", "operator@example.com", "operator123",
+                List.of("OPERATOR"));
+    }
+
+    @Override
+    public CreateUserResult createUser(final CreateUserCommand command) {
+        Objects.requireNonNull(command, "command");
+        ensureUsernameAvailable(command.username());
+        ensureEmailAvailable(command.email());
+
+        final String id = nextId();
+        final Set<String> roles = normalizeRoles(command.roles());
+        final User user = new User(
+                id,
+                command.username(),
+                command.displayName(),
+                command.email(),
+                command.password(),
+                UserStatus.PENDING_ACTIVATION,
+                roles);
+        final ActivationToken token = new ActivationToken(generateToken(), expiration());
+        user.issueActivationToken(token);
+        save(user);
+        return new CreateUserResult(toView(user), new ActivationLink(token.token(), token.expiresAt()));
+    }
+
+    @Override
+    public ActivationLink resendActivation(final String userId) {
+        final User user = getRequiredById(userId);
+        if (user.getStatus() == UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_ACTIVE);
+        }
+        final ActivationToken token = new ActivationToken(generateToken(), expiration());
+        user.issueActivationToken(token);
+        return new ActivationLink(token.token(), token.expiresAt());
+    }
+
+    @Override
+    public UserView activateUser(final String token) {
+        if (!StringUtils.hasText(token)) {
+            throw new BusinessException(ErrorCode.ACTIVATION_TOKEN_INVALID);
+        }
+        final User user = findByActivationToken(token)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ACTIVATION_TOKEN_INVALID));
+        final ActivationToken activationToken = user.getActivationToken();
+        if (activationToken == null) {
+            throw new BusinessException(ErrorCode.ACTIVATION_TOKEN_INVALID);
+        }
+        if (activationToken.isExpired(clock.instant())) {
+            throw new BusinessException(ErrorCode.ACTIVATION_TOKEN_EXPIRED);
+        }
+        if (user.getStatus() == UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_ACTIVE);
+        }
+        user.activate();
+        user.clearActivation();
+        return toView(user);
+    }
+
+    @Override
+    public UserView assignRoles(final String userId, final List<String> roles) {
+        final User user = getRequiredById(userId);
+        final Set<String> normalized = normalizeRoles(roles);
+        user.assignRoles(normalized);
+        return toView(user);
+    }
+
+    @Override
+    public List<UserView> listUsers(final UserQuery query) {
+        return usersById.values().stream()
+                .sorted(Comparator.comparing(User::getUsername))
+                .filter(user -> query == null || query.status() == null || user.getStatus() == query.status())
+                .map(this::toView)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public UserView getUser(final String userId) {
+        return toView(getRequiredById(userId));
+    }
 
     @Override
     public UserAuthentication authenticate(final String username, final String password) {
-        final UserRecord user = users.get(username.toLowerCase());
-        if (user == null || !user.password().equals(password)) {
+        final User user = getRequiredByUsername(username);
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.USER_INACTIVE);
+        }
+        if (!user.passwordMatches(password)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "auth.invalid_credentials");
         }
-        return new UserAuthentication(user.id(), user.username(), user.displayName(), UserStatus.ACTIVE, user.roles());
+        return new UserAuthentication(user.getId(), user.getUsername(), user.getDisplayName(), user.getStatus(),
+                new ArrayList<>(user.getRoles()));
     }
 
     @Override
     public UserView loadUserByUsername(final String username) {
-        final UserRecord user = users.get(username.toLowerCase());
-        if (user == null) {
-            throw new BusinessException(ErrorCode.USER_NOT_FOUND, "user.not_found");
-        }
-        return new UserView(user.id(), user.username(), user.displayName(), user.email(), UserStatus.ACTIVE, user.roles());
+        return toView(getRequiredByUsername(username));
     }
 
-    private record UserRecord(String id, String username, String displayName, String email, String password, List<String> roles) {
+    private void registerActiveUser(
+            final String id,
+            final String username,
+            final String displayName,
+            final String email,
+            final String password,
+            final List<String> roles) {
+        final User user = new User(id, username, displayName, email, password, UserStatus.ACTIVE, normalizeRoles(roles));
+        user.clearActivation();
+        save(user);
+    }
+
+    private void ensureUsernameAvailable(final String username) {
+        final String key = normalizeUsername(username);
+        if (usersByUsername.containsKey(key)) {
+            throw new BusinessException(ErrorCode.USERNAME_EXISTS);
+        }
+    }
+
+    private void ensureEmailAvailable(final String email) {
+        if (!StringUtils.hasText(email)) {
+            return;
+        }
+        final boolean exists = usersById.values().stream()
+                .anyMatch(user -> user.getEmail().equalsIgnoreCase(email));
+        if (exists) {
+            throw new BusinessException(ErrorCode.EMAIL_EXISTS);
+        }
+    }
+
+    private User getRequiredById(final String userId) {
+        final User user = usersById.get(userId);
+        if (user == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return user;
+    }
+
+    private User getRequiredByUsername(final String username) {
+        if (!StringUtils.hasText(username)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        final User user = usersByUsername.get(normalizeUsername(username));
+        if (user == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return user;
+    }
+
+    private Optional<User> findByActivationToken(final String token) {
+        return usersById.values().stream()
+                .filter(user -> user.getActivationToken() != null)
+                .filter(user -> token.equals(user.getActivationToken().token()))
+                .findFirst();
+    }
+
+    private void save(final User user) {
+        usersById.put(user.getId(), user);
+        usersByUsername.put(normalizeUsername(user.getUsername()), user);
+    }
+
+    private UserView toView(final User user) {
+        return new UserView(
+                user.getId(),
+                user.getUsername(),
+                user.getDisplayName(),
+                user.getEmail(),
+                user.getStatus(),
+                new ArrayList<>(user.getRoles()));
+    }
+
+    private String normalizeUsername(final String username) {
+        return Objects.requireNonNull(username, "username").toLowerCase(Locale.ROOT);
+    }
+
+    private Set<String> normalizeRoles(final List<String> roles) {
+        if (CollectionUtils.isEmpty(roles)) {
+            return new LinkedHashSet<>(List.of("ROLE_OPERATOR"));
+        }
+        return roles.stream()
+                .filter(StringUtils::hasText)
+                .map(role -> role.trim().toUpperCase(Locale.ROOT))
+                .map(role -> role.startsWith("ROLE_") ? role : "ROLE_" + role)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private String nextId() {
+        return Long.toString(idSequence.incrementAndGet());
+    }
+
+    private Instant expiration() {
+        return clock.instant().plus(activationTtl);
+    }
+
+    private String generateToken() {
+        return UUID.randomUUID().toString();
     }
 }

--- a/backend/src/test/java/com/bob/mta/api/PingControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/api/PingControllerTest.java
@@ -1,55 +1,21 @@
 package com.bob.mta.api;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import com.bob.mta.common.api.ApiResponse;
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-class PingControllerTest {
-
-    @Test
-    void pingShouldReturnOk() {
-        PingController controller = new PingController();
-        ApiResponse<?> response = controller.ping();
-        assertThat(response.isSuccess()).isTrue();
-        assertThat(response.getData()).asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.MAP)
-                .containsEntry("status", "ok");
-    }
-}
-<<<<<<< HEAD
-=======
-=======
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
+import com.bob.mta.common.api.ApiResponse;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
-@AutoConfigureMockMvc
 class PingControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-
     @Test
-    @DisplayName("ping endpoint is publicly accessible")
-    void shouldReturnOkStatus() throws Exception {
-        mockMvc.perform(get("/api/ping"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(0))
-                .andExpect(jsonPath("$.data.status").value("ok"));
+    @DisplayName("ping endpoint returns ok status")
+    void shouldReturnOkStatus() {
+        final PingController controller = new PingController();
+
+        final ApiResponse<Map<String, String>> response = controller.ping();
+
+        assertThat(response.getData()).containsEntry("status", "ok");
     }
 }
-
->>>>>>> origin/main
->>>>>>> origin/main

--- a/backend/src/test/java/com/bob/mta/common/api/ApiResponseTest.java
+++ b/backend/src/test/java/com/bob/mta/common/api/ApiResponseTest.java
@@ -1,36 +1,5 @@
 package com.bob.mta.common.api;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-class ApiResponseTest {
-
-    @Test
-    void successShouldContainData() {
-        ApiResponse<String> response = ApiResponse.success("ok");
-        assertThat(response.isSuccess()).isTrue();
-        assertThat(response.getData()).isEqualTo("ok");
-        assertThat(response.getCode()).isEqualTo("OK");
-        assertThat(response.getMessage()).isEqualTo("success");
-    }
-
-    @Test
-    void failureShouldContainErrorInfo() {
-        ApiResponse<Object> response = ApiResponse.failure("ERR", "failure");
-        assertThat(response.isSuccess()).isFalse();
-        assertThat(response.getCode()).isEqualTo("ERR");
-        assertThat(response.getMessage()).isEqualTo("failure");
-        assertThat(response.getData()).isNull();
-    }
-}
-<<<<<<< HEAD
-=======
-=======
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bob.mta.common.exception.ErrorCode;
@@ -59,6 +28,3 @@ class ApiResponseTest {
         assertThat(response.getData()).isEqualTo("context");
     }
 }
-
->>>>>>> origin/main
->>>>>>> origin/main

--- a/backend/src/test/java/com/bob/mta/common/api/PageResponseTest.java
+++ b/backend/src/test/java/com/bob/mta/common/api/PageResponseTest.java
@@ -1,43 +1,14 @@
 package com.bob.mta.common.api;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-<<<<<<< HEAD
-=======
-=======
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
->>>>>>> origin/main
->>>>>>> origin/main
 
 class PageResponseTest {
 
     @Test
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    void ofShouldExposePaginationInfo() {
-        PageResponse<String> response = PageResponse.of(List.of("a", "b"), 5, 1, 2);
-        assertThat(response.getItems()).containsExactly("a", "b");
-        assertThat(response.getTotal()).isEqualTo(5);
-        assertThat(response.getPage()).isEqualTo(1);
-        assertThat(response.getSize()).isEqualTo(2);
-    }
-}
-<<<<<<< HEAD
-=======
-=======
     @DisplayName("page response captures metadata and performs defensive copy")
     void shouldCreatePageResponse() {
         final List<String> rows = List.of("a", "b");
@@ -52,6 +23,3 @@ class PageResponseTest {
         assertThat(page.getList()).isNotSameAs(rows);
     }
 }
-
->>>>>>> origin/main
->>>>>>> origin/main

--- a/backend/src/test/java/com/bob/mta/common/security/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/JwtAuthenticationFilterTest.java
@@ -1,23 +1,5 @@
 package com.bob.mta.common.security;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-<<<<<<< HEAD
-=======
-=======
 import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.servlet.ServletException;
@@ -28,31 +10,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockFilterChain;
->>>>>>> origin/main
->>>>>>> origin/main
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-
-class JwtAuthenticationFilterTest {
-
-<<<<<<< HEAD
-=======
-=======
 class JwtAuthenticationFilterTest {
 
     private JwtAuthenticationFilter filter;
@@ -68,36 +29,12 @@ class JwtAuthenticationFilterTest {
         filter = new JwtAuthenticationFilter(tokenProvider);
     }
 
->>>>>>> origin/main
->>>>>>> origin/main
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
     }
 
     @Test
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    void filterShouldPopulateSecurityContextWhenTokenPresent() throws ServletException, IOException {
-        JwtProperties properties = new JwtProperties();
-        properties.getAccessToken().setSecret("a-very-long-secret-key-for-tests-1234567890");
-        JwtTokenProvider provider = new JwtTokenProvider(properties);
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(provider);
-
-        String token = provider.createToken("u-1", "admin", List.of("ROLE_ADMIN"));
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addHeader("Authorization", "Bearer " + token);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        FilterChain filterChain = Mockito.mock(FilterChain.class);
-
-        filter.doFilter(request, response, filterChain);
-
-        verify(filterChain).doFilter(request, response);
-<<<<<<< HEAD
-=======
-=======
     @DisplayName("filter populates SecurityContext for valid bearer token")
     void shouldAuthenticateRequestWhenTokenPresent() throws ServletException, IOException {
         final String token = tokenProvider.generateToken("1", "admin", "ADMIN");
@@ -106,36 +43,11 @@ class JwtAuthenticationFilterTest {
 
         filter.doFilterInternal(request, new MockHttpServletResponse(), new MockFilterChain());
 
->>>>>>> origin/main
->>>>>>> origin/main
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
         assertThat(SecurityContextHolder.getContext().getAuthentication().getName()).isEqualTo("admin");
     }
 
     @Test
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    void filterShouldSkipWhenTokenMissing() throws ServletException, IOException {
-        JwtProperties properties = new JwtProperties();
-        properties.getAccessToken().setSecret("a-very-long-secret-key-for-tests-1234567890");
-        JwtTokenProvider provider = new JwtTokenProvider(properties);
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(provider);
-
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        FilterChain filterChain = Mockito.mock(FilterChain.class);
-
-        filter.doFilter(request, response, filterChain);
-
-        verify(filterChain).doFilter(request, response);
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-    }
-}
-<<<<<<< HEAD
-=======
-=======
     @DisplayName("filter ignores malformed bearer tokens")
     void shouldIgnoreInvalidTokens() throws ServletException, IOException {
         final MockHttpServletRequest request = new MockHttpServletRequest();
@@ -146,6 +58,3 @@ class JwtAuthenticationFilterTest {
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 }
-
->>>>>>> origin/main
->>>>>>> origin/main

--- a/backend/src/test/java/com/bob/mta/common/security/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/JwtTokenProviderTest.java
@@ -1,36 +1,5 @@
 package com.bob.mta.common.security;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import io.jsonwebtoken.Claims;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-class JwtTokenProviderTest {
-
-    @Test
-    void createTokenShouldEmbedClaims() {
-        JwtProperties properties = new JwtProperties();
-        properties.getAccessToken().setSecret("a-very-long-secret-key-for-tests-1234567890");
-        properties.getAccessToken().setExpirationMinutes(5);
-        JwtTokenProvider provider = new JwtTokenProvider(properties);
-
-        String token = provider.createToken("123", "admin", List.of("ROLE_ADMIN"));
-        Claims claims = provider.parseClaims(token);
-
-        assertThat(claims.getSubject()).isEqualTo("123");
-        assertThat(claims.get("username")).isEqualTo("admin");
-        assertThat((List<?>) claims.get("roles")).containsExactly("ROLE_ADMIN");
-    }
-}
-<<<<<<< HEAD
-=======
-=======
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
@@ -74,6 +43,3 @@ class JwtTokenProviderTest {
         assertThat(tokenProvider.parseToken(token)).isEmpty();
     }
 }
-
->>>>>>> origin/main
->>>>>>> origin/main

--- a/backend/src/test/java/com/bob/mta/common/security/RestAccessDeniedHandlerTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/RestAccessDeniedHandlerTest.java
@@ -1,68 +1,32 @@
 package com.bob.mta.common.security;
 
-<<<<<<< HEAD
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
-=======
-<<<<<<< HEAD
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
-=======
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
->>>>>>> origin/main
->>>>>>> origin/main
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockHttpServletRequest;
+import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-class RestAccessDeniedHandlerTest {
-
-    @Test
-    void handleShouldWriteJsonResponse() throws ServletException, IOException {
-        RestAccessDeniedHandler handler = new RestAccessDeniedHandler(new ObjectMapper());
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        handler.handle(new MockHttpServletRequest(), response, new AccessDeniedException("denied"));
-
-        assertThat(response.getStatus()).isEqualTo(403);
-        assertThat(response.getContentAsString()).contains("ACCESS_DENIED");
-    }
-}
-<<<<<<< HEAD
-=======
-=======
 class RestAccessDeniedHandlerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RestAccessDeniedHandler handler = new RestAccessDeniedHandler(objectMapper);
 
     @Test
-    @DisplayName("forbidden access returns API error envelope")
+    @DisplayName("handler writes forbidden response body")
     void shouldWriteForbiddenResponse() throws IOException {
+        final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         final MockHttpServletResponse response = new MockHttpServletResponse();
 
-        handler.handle(new MockHttpServletRequest(), response, new AccessDeniedException("forbidden"));
+        handler.handle(request, response, new AccessDeniedException("forbidden"));
 
-        assertThat(response.getStatus()).isEqualTo(403);
-        final JsonNode body = objectMapper.readTree(response.getContentAsString());
-        assertThat(body.path("code").asInt()).isEqualTo(4031);
-        assertThat(body.path("message").asText()).isNotBlank();
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+        assertThat(response.getContentType()).isEqualTo("application/json");
+        assertThat(response.getContentAsString()).contains("auth.forbidden");
     }
 }
-
->>>>>>> origin/main
->>>>>>> origin/main

--- a/backend/src/test/java/com/bob/mta/common/security/RestAuthenticationEntryPointTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/RestAuthenticationEntryPointTest.java
@@ -1,69 +1,32 @@
 package com.bob.mta.common.security;
 
-<<<<<<< HEAD
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
-=======
-<<<<<<< HEAD
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
-=======
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
->>>>>>> origin/main
->>>>>>> origin/main
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockHttpServletRequest;
+import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-class RestAuthenticationEntryPointTest {
-
-    @Test
-    void commenceShouldWriteUnauthorizedJson() throws ServletException, IOException {
-        RestAuthenticationEntryPoint entryPoint = new RestAuthenticationEntryPoint(new ObjectMapper());
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        entryPoint.commence(new MockHttpServletRequest(), response, new AuthenticationException("bad") {});
-
-        assertThat(response.getStatus()).isEqualTo(401);
-        assertThat(response.getContentAsString()).contains("AUTHENTICATION_FAILED");
-    }
-}
-<<<<<<< HEAD
-=======
-=======
 class RestAuthenticationEntryPointTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RestAuthenticationEntryPoint entryPoint = new RestAuthenticationEntryPoint(objectMapper);
 
     @Test
-    @DisplayName("unauthenticated access renders JSON envelope")
-    void shouldWriteUnauthorizedResponse() throws IOException, ServletException {
+    @DisplayName("entry point writes unauthorized response")
+    void shouldWriteUnauthorizedResponse() throws IOException {
+        final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         final MockHttpServletResponse response = new MockHttpServletResponse();
 
-        entryPoint.commence(new MockHttpServletRequest(), response, new AuthenticationException("denied") {});
+        entryPoint.commence(request, response, new AuthenticationException("unauthorized") { });
 
-        assertThat(response.getStatus()).isEqualTo(401);
-        final JsonNode body = objectMapper.readTree(response.getContentAsString());
-        assertThat(body.path("code").asInt()).isEqualTo(4010);
-        assertThat(body.path("message").asText()).isNotEmpty();
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+        assertThat(response.getContentType()).isEqualTo("application/json");
+        assertThat(response.getContentAsString()).contains("auth.required");
     }
 }
-
->>>>>>> origin/main
->>>>>>> origin/main

--- a/backend/src/test/java/com/bob/mta/modules/customer/controller/CustomerControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/customer/controller/CustomerControllerTest.java
@@ -1,21 +1,15 @@
 package com.bob.mta.modules.customer.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bob.mta.common.api.ApiResponse;
 import com.bob.mta.common.api.PageResponse;
 import com.bob.mta.modules.customer.dto.CustomerDetailResponse;
 import com.bob.mta.modules.customer.dto.CustomerSummaryResponse;
-<<<<<<< HEAD
-import com.bob.mta.modules.customfield.service.impl.InMemoryCustomFieldService;
 import com.bob.mta.modules.customer.service.impl.InMemoryCustomerService;
-import com.bob.mta.modules.tag.service.impl.InMemoryTagService;
-=======
-import com.bob.mta.modules.customer.service.impl.InMemoryCustomerService;
->>>>>>> origin/main
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class CustomerControllerTest {
 
@@ -23,26 +17,22 @@ class CustomerControllerTest {
 
     @BeforeEach
     void setUp() {
-<<<<<<< HEAD
-        InMemoryTagService tagService = new InMemoryTagService();
-        InMemoryCustomFieldService customFieldService = new InMemoryCustomFieldService();
-        controller = new CustomerController(new InMemoryCustomerService(tagService, customFieldService));
-=======
         controller = new CustomerController(new InMemoryCustomerService());
->>>>>>> origin/main
     }
 
     @Test
-    void searchShouldReturnPagedResults() {
-        PageResponse<CustomerSummaryResponse> page = controller.search("", "", 0, 1).getData();
-        assertThat(page.getItems()).hasSize(1);
-        assertThat(page.getTotal()).isGreaterThanOrEqualTo(2);
+    @DisplayName("list endpoint delegates to service and returns page response")
+    void shouldListCustomers() {
+        final ApiResponse<PageResponse<CustomerSummaryResponse>> response = controller.list(1, 20, null, null);
+
+        assertThat(response.getData().getList()).isNotEmpty();
     }
 
     @Test
-    void detailShouldReturnCustomerInfo() {
-        CustomerDetailResponse response = controller.detail("cust-001").getData();
-        assertThat(response.getId()).isEqualTo("cust-001");
-        assertThat(response.getCustomFields()).isNotEmpty();
+    @DisplayName("detail endpoint returns customer information")
+    void shouldReturnCustomerDetail() {
+        final ApiResponse<CustomerDetailResponse> response = controller.detail("101");
+
+        assertThat(response.getData().id()).isEqualTo("101");
     }
 }

--- a/backend/src/test/java/com/bob/mta/modules/customer/service/impl/InMemoryCustomerServiceTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/customer/service/impl/InMemoryCustomerServiceTest.java
@@ -3,72 +3,40 @@ package com.bob.mta.modules.customer.service.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-<<<<<<< HEAD
-import com.bob.mta.common.exception.BusinessException;
-import com.bob.mta.modules.customer.domain.Customer;
-import com.bob.mta.modules.customfield.service.impl.InMemoryCustomFieldService;
-import com.bob.mta.modules.tag.service.impl.InMemoryTagService;
-=======
 import com.bob.mta.common.api.PageResponse;
 import com.bob.mta.common.exception.BusinessException;
 import com.bob.mta.modules.customer.dto.CustomerDetailResponse;
 import com.bob.mta.modules.customer.dto.CustomerSummaryResponse;
->>>>>>> origin/main
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class InMemoryCustomerServiceTest {
 
-<<<<<<< HEAD
-    private final InMemoryTagService tagService = new InMemoryTagService();
-    private final InMemoryCustomFieldService customFieldService = new InMemoryCustomFieldService();
-    private final InMemoryCustomerService service = new InMemoryCustomerService(tagService, customFieldService);
-=======
     private final InMemoryCustomerService service = new InMemoryCustomerService();
->>>>>>> origin/main
 
     @Test
     @DisplayName("keyword filter performs case-insensitive matching")
     void shouldFilterCustomersByKeyword() {
-<<<<<<< HEAD
-        final java.util.List<Customer> result = service.search("东京", "");
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getName()).contains("东京");
-=======
         final PageResponse<CustomerSummaryResponse> response = service.listCustomers(1, 20, "tokyo", null);
 
         assertThat(response.getList()).hasSize(1);
         assertThat(response.getList().get(0).name()).contains("东京");
->>>>>>> origin/main
     }
 
     @Test
     @DisplayName("missing customer id raises BusinessException")
     void shouldThrowWhenCustomerMissing() {
-<<<<<<< HEAD
-        assertThatThrownBy(() -> service.getById("missing"))
-=======
         assertThatThrownBy(() -> service.getCustomer("missing"))
->>>>>>> origin/main
                 .isInstanceOf(BusinessException.class);
     }
 
     @Test
     @DisplayName("customer detail returns immutable view of custom fields")
     void shouldExposeCustomerDetail() {
-<<<<<<< HEAD
-        final Customer detail = service.getById("cust-001");
-
-        assertThat(detail.getId()).isEqualTo("cust-001");
-        assertThat(detail.getCustomFields()).isNotEmpty();
-        assertThat(detail.getTags()).contains("重点客户");
-=======
         final CustomerDetailResponse detail = service.getCustomer("101");
 
         assertThat(detail.id()).isEqualTo("101");
         assertThat(detail.fields()).isNotEmpty();
         assertThat(detail.tags()).contains("重点客户");
->>>>>>> origin/main
     }
 }
-

--- a/backend/src/test/java/com/bob/mta/modules/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/user/controller/UserControllerTest.java
@@ -1,19 +1,20 @@
 package com.bob.mta.modules.user.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.bob.mta.common.api.ApiResponse;
+import com.bob.mta.modules.user.domain.UserStatus;
 import com.bob.mta.modules.user.dto.ActivateUserRequest;
 import com.bob.mta.modules.user.dto.ActivationLinkResponse;
 import com.bob.mta.modules.user.dto.AssignRolesRequest;
 import com.bob.mta.modules.user.dto.CreateUserRequest;
 import com.bob.mta.modules.user.dto.UserResponse;
 import com.bob.mta.modules.user.service.impl.InMemoryUserService;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class UserControllerTest {
 
@@ -22,51 +23,80 @@ class UserControllerTest {
 
     @BeforeEach
     void setUp() {
-        userService = new InMemoryUserService(new BCryptPasswordEncoder());
+        userService = new InMemoryUserService(new MutableClock(Instant.parse("2024-01-01T00:00:00Z")));
+        userService.seedDefaultUsers();
         controller = new UserController(userService);
     }
 
     @Test
     void createUserShouldReturnResponse() {
-        CreateUserRequest request = new CreateUserRequest();
+        final CreateUserRequest request = new CreateUserRequest();
         request.setUsername("controller");
         request.setDisplayName("Controller User");
         request.setEmail("controller@demo.com");
+        request.setPassword("password123");
 
-        ApiResponse<UserResponse> response = controller.createUser(request);
+        final ApiResponse<UserResponse> response = controller.createUser(request);
 
         assertThat(response.getData().getUsername()).isEqualTo("controller");
+        assertThat(response.getData().getStatus()).isEqualTo(UserStatus.PENDING_ACTIVATION);
     }
 
     @Test
-    void activationEndpointsShouldReturnTokens() {
-        CreateUserRequest request = new CreateUserRequest();
+    void activationEndpointsShouldActivateUser() {
+        final CreateUserRequest request = new CreateUserRequest();
         request.setUsername("to-activate");
         request.setDisplayName("To Activate");
         request.setEmail("activate@demo.com");
-        String userId = controller.createUser(request).getData().getId();
+        request.setPassword("password123");
+        final String userId = controller.createUser(request).getData().getId();
 
-        ActivationLinkResponse resend = controller.resendActivation(userId).getData();
-        ActivateUserRequest activateUserRequest = new ActivateUserRequest();
+        final ActivationLinkResponse resend = controller.resendActivation(userId).getData();
+        final ActivateUserRequest activateUserRequest = new ActivateUserRequest();
         activateUserRequest.setToken(resend.getToken());
-        ActivationLinkResponse activated = controller.activate(activateUserRequest).getData();
+        final ApiResponse<UserResponse> activated = controller.activate(activateUserRequest);
 
-        assertThat(activated.getToken()).isEqualTo(resend.getToken());
+        assertThat(activated.getData().getStatus()).isEqualTo(UserStatus.ACTIVE);
     }
 
     @Test
     void assignRolesShouldUpdateUser() {
-        CreateUserRequest request = new CreateUserRequest();
+        final CreateUserRequest request = new CreateUserRequest();
         request.setUsername("role-change");
         request.setDisplayName("Role Change");
         request.setEmail("role@demo.com");
-        String userId = controller.createUser(request).getData().getId();
+        request.setPassword("password123");
+        final String userId = controller.createUser(request).getData().getId();
 
-        AssignRolesRequest assign = new AssignRolesRequest();
+        final AssignRolesRequest assign = new AssignRolesRequest();
         assign.setRoles(List.of("auditor"));
 
-        UserResponse response = controller.assignRoles(userId, assign).getData();
+        final UserResponse response = controller.assignRoles(userId, assign).getData();
 
         assertThat(response.getRoles()).containsExactly("ROLE_AUDITOR");
+    }
+
+    private static final class MutableClock extends java.time.Clock {
+
+        private Instant instant;
+
+        private MutableClock(final Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public java.time.Clock withZone(final java.time.ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
     }
 }

--- a/backend/src/test/java/com/bob/mta/modules/user/service/impl/InMemoryUserServiceTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/user/service/impl/InMemoryUserServiceTest.java
@@ -1,90 +1,5 @@
 package com.bob.mta.modules.user.service.impl;
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-import com.bob.mta.common.exception.BusinessException;
-import com.bob.mta.common.exception.ErrorCode;
-import com.bob.mta.modules.user.domain.User;
-import com.bob.mta.modules.user.domain.UserStatus;
-import com.bob.mta.modules.user.dto.ActivationLinkResponse;
-import com.bob.mta.modules.user.dto.CreateUserRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-class InMemoryUserServiceTest {
-
-    private InMemoryUserService userService;
-
-    @BeforeEach
-    void setUp() {
-        PasswordEncoder encoder = new BCryptPasswordEncoder();
-        userService = new InMemoryUserService(encoder);
-    }
-
-    @Test
-    void createUserShouldPersistPendingAccount() {
-        CreateUserRequest request = new CreateUserRequest();
-        request.setUsername("newuser");
-        request.setDisplayName("New User");
-        request.setEmail("new@demo.com");
-        request.setRoles(List.of("admin"));
-
-        User user = userService.createUser(request);
-
-        assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING_ACTIVATION);
-        assertThat(userService.findByUsername("newuser")).isPresent();
-    }
-
-    @Test
-    void createUserShouldFailWhenUsernameExists() {
-        CreateUserRequest request = new CreateUserRequest();
-        request.setUsername("admin");
-        request.setDisplayName("Dup");
-        request.setEmail("dup@demo.com");
-
-        assertThatThrownBy(() -> userService.createUser(request))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ErrorCode.USERNAME_EXISTS.getCode());
-    }
-
-    @Test
-    void activationFlowShouldUpdateStatus() {
-        CreateUserRequest request = new CreateUserRequest();
-        request.setUsername("activate");
-        request.setDisplayName("Need Activation");
-        request.setEmail("activate@demo.com");
-        User user = userService.createUser(request);
-
-        ActivationLinkResponse resend = userService.resendActivation(user.getId());
-        ActivationLinkResponse activation = userService.activateUser(resend.getToken());
-
-        assertThat(activation.getToken()).isEqualTo(resend.getToken());
-        assertThat(userService.getById(user.getId()).getStatus()).isEqualTo(UserStatus.ACTIVE);
-    }
-
-    @Test
-    void assignRolesShouldNormalizeRoleNames() {
-        CreateUserRequest request = new CreateUserRequest();
-        request.setUsername("roleuser");
-        request.setDisplayName("Role User");
-        request.setEmail("role@demo.com");
-        User user = userService.createUser(request);
-
-        User updated = userService.assignRoles(user.getId(), List.of("viewer", "ROLE_operator"));
-
-        assertThat(updated.getRoles()).containsExactlyInAnyOrder("ROLE_VIEWER", "ROLE_OPERATOR");
-<<<<<<< HEAD
-=======
-=======
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -226,7 +141,7 @@ class InMemoryUserServiceTest {
         final UserAuthentication auth = service.authenticate("admin", "admin123");
 
         assertThat(auth.username()).isEqualTo("admin");
-        assertThat(auth.roles()).contains("ADMIN");
+        assertThat(auth.roles()).contains("ROLE_ADMIN");
     }
 
     @Test
@@ -274,7 +189,5 @@ class InMemoryUserServiceTest {
         private void advance(final java.time.Duration duration) {
             instant = instant.plus(duration);
         }
->>>>>>> origin/main
->>>>>>> origin/main
     }
 }


### PR DESCRIPTION
## Summary
- add REST endpoints for listing, creating, activating and managing user roles
- expand the in-memory user service with activation lifecycle, duplicate checks and role normalization
- refresh unit tests across user, customer and security modules to match the updated APIs

## Testing
- `mvn -f backend/pom.xml -DskipTests package` *(fails: unable to download parent POM from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d7461182a0832f92526ad38735a357