### PR TITLE
feat: design plan persistence aggregate

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanActivityEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanActivityEntity.java
@@ -1,0 +1,22 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanActivityType;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+public record PlanActivityEntity(
+        String planId,
+        String activityId,
+        PlanActivityType type,
+        OffsetDateTime occurredAt,
+        String actor,
+        String message,
+        String referenceId,
+        Map<String, String> attributes
+) {
+
+    public PlanActivityEntity {
+        attributes = attributes == null ? Map.of() : Map.copyOf(attributes);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanAggregate.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanAggregate.java
@@ -1,0 +1,26 @@
+package com.bob.mta.modules.plan.persistence;
+
+import java.util.List;
+
+public record PlanAggregate(
+        PlanEntity plan,
+        List<PlanParticipantEntity> participants,
+        List<PlanNodeEntity> nodes,
+        List<PlanNodeExecutionEntity> executions,
+        List<PlanNodeAttachmentEntity> attachments,
+        List<PlanActivityEntity> activities,
+        List<PlanReminderRuleEntity> reminderRules
+) {
+
+    public PlanAggregate {
+        if (plan == null) {
+            throw new IllegalArgumentException("plan must not be null");
+        }
+        participants = participants == null ? List.of() : List.copyOf(participants);
+        nodes = nodes == null ? List.of() : List.copyOf(nodes);
+        executions = executions == null ? List.of() : List.copyOf(executions);
+        attachments = attachments == null ? List.of() : List.copyOf(attachments);
+        activities = activities == null ? List.of() : List.copyOf(activities);
+        reminderRules = reminderRules == null ? List.of() : List.copyOf(reminderRules);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanEntity.java
@@ -1,0 +1,28 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanStatus;
+
+import java.time.OffsetDateTime;
+
+public record PlanEntity(
+        String id,
+        String tenantId,
+        String customerId,
+        String owner,
+        String title,
+        String description,
+        PlanStatus status,
+        OffsetDateTime plannedStartTime,
+        OffsetDateTime plannedEndTime,
+        OffsetDateTime actualStartTime,
+        OffsetDateTime actualEndTime,
+        String cancelReason,
+        String canceledBy,
+        OffsetDateTime canceledAt,
+        String timezone,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt,
+        OffsetDateTime reminderUpdatedAt,
+        String reminderUpdatedBy
+) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeAttachmentEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeAttachmentEntity.java
@@ -1,0 +1,4 @@
+package com.bob.mta.modules.plan.persistence;
+
+public record PlanNodeAttachmentEntity(String planId, String nodeId, String fileId) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeEntity.java
@@ -1,0 +1,15 @@
+package com.bob.mta.modules.plan.persistence;
+
+public record PlanNodeEntity(
+        String planId,
+        String nodeId,
+        String parentNodeId,
+        String name,
+        String type,
+        String assignee,
+        int orderIndex,
+        Integer expectedDurationMinutes,
+        String actionRef,
+        String description
+) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeExecutionEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeExecutionEntity.java
@@ -1,0 +1,17 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanNodeStatus;
+
+import java.time.OffsetDateTime;
+
+public record PlanNodeExecutionEntity(
+        String planId,
+        String nodeId,
+        PlanNodeStatus status,
+        OffsetDateTime startTime,
+        OffsetDateTime endTime,
+        String operator,
+        String result,
+        String log
+) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanParticipantEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanParticipantEntity.java
@@ -1,0 +1,4 @@
+package com.bob.mta.modules.plan.persistence;
+
+public record PlanParticipantEntity(String planId, String participantId) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanPersistenceMapper.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanPersistenceMapper.java
@@ -1,0 +1,246 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanActivity;
+import com.bob.mta.modules.plan.domain.PlanNode;
+import com.bob.mta.modules.plan.domain.PlanNodeExecution;
+import com.bob.mta.modules.plan.domain.PlanReminderPolicy;
+import com.bob.mta.modules.plan.domain.PlanReminderRule;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class PlanPersistenceMapper {
+
+    private PlanPersistenceMapper() {
+    }
+
+    public static PlanAggregate toAggregate(Plan plan) {
+        Objects.requireNonNull(plan, "plan");
+        PlanEntity planEntity = new PlanEntity(
+                plan.getId(),
+                plan.getTenantId(),
+                plan.getCustomerId(),
+                plan.getOwner(),
+                plan.getTitle(),
+                plan.getDescription(),
+                plan.getStatus(),
+                plan.getPlannedStartTime(),
+                plan.getPlannedEndTime(),
+                plan.getActualStartTime(),
+                plan.getActualEndTime(),
+                plan.getCancelReason(),
+                plan.getCanceledBy(),
+                plan.getCanceledAt(),
+                plan.getTimezone(),
+                plan.getCreatedAt(),
+                plan.getUpdatedAt(),
+                plan.getReminderPolicy().getUpdatedAt(),
+                plan.getReminderPolicy().getUpdatedBy()
+        );
+
+        List<PlanParticipantEntity> participants = plan.getParticipants().stream()
+                .map(participant -> new PlanParticipantEntity(plan.getId(), participant))
+                .collect(Collectors.toList());
+
+        List<PlanNodeEntity> nodeEntities = new ArrayList<>();
+        flattenNodes(plan.getId(), plan.getNodes(), null, nodeEntities);
+
+        List<PlanNodeExecutionEntity> executions = plan.getExecutions().stream()
+                .map(execution -> new PlanNodeExecutionEntity(
+                        plan.getId(),
+                        execution.getNodeId(),
+                        execution.getStatus(),
+                        execution.getStartTime(),
+                        execution.getEndTime(),
+                        execution.getOperator(),
+                        execution.getResult(),
+                        execution.getLog()
+                ))
+                .collect(Collectors.toList());
+
+        List<PlanNodeAttachmentEntity> attachments = plan.getExecutions().stream()
+                .flatMap(execution -> execution.getFileIds().stream()
+                        .map(fileId -> new PlanNodeAttachmentEntity(plan.getId(), execution.getNodeId(), fileId)))
+                .collect(Collectors.toList());
+
+        List<PlanActivityEntity> activities = new ArrayList<>();
+        List<PlanActivity> domainActivities = plan.getActivities();
+        for (int index = 0; index < domainActivities.size(); index++) {
+            PlanActivity activity = domainActivities.get(index);
+            String activityId = plan.getId() + "-activity-" + (index + 1);
+            activities.add(new PlanActivityEntity(
+                    plan.getId(),
+                    activityId,
+                    activity.getType(),
+                    activity.getOccurredAt(),
+                    activity.getActor(),
+                    activity.getMessage(),
+                    activity.getReferenceId(),
+                    activity.getAttributes()
+            ));
+        }
+
+        List<PlanReminderRuleEntity> reminderRules = plan.getReminderPolicy().getRules().stream()
+                .map(rule -> new PlanReminderRuleEntity(
+                        plan.getId(),
+                        rule.getId(),
+                        rule.getTrigger(),
+                        rule.getOffsetMinutes(),
+                        rule.getChannels(),
+                        rule.getTemplateId(),
+                        rule.getRecipients(),
+                        rule.getDescription()
+                ))
+                .collect(Collectors.toList());
+
+        return new PlanAggregate(planEntity, participants, nodeEntities, executions, attachments, activities, reminderRules);
+    }
+
+    public static Plan toDomain(PlanAggregate aggregate) {
+        Objects.requireNonNull(aggregate, "aggregate");
+        PlanEntity entity = aggregate.plan();
+
+        List<String> participants = aggregate.participants().stream()
+                .map(PlanParticipantEntity::participantId)
+                .collect(Collectors.toList());
+
+        Map<String, List<String>> attachmentsByNode = aggregate.attachments().stream()
+                .collect(Collectors.groupingBy(
+                        PlanNodeAttachmentEntity::nodeId,
+                        Collectors.mapping(PlanNodeAttachmentEntity::fileId, Collectors.toCollection(ArrayList::new))
+                ));
+
+        List<PlanNodeExecution> executions = aggregate.executions().stream()
+                .map(execution -> new PlanNodeExecution(
+                        execution.nodeId(),
+                        execution.status(),
+                        execution.startTime(),
+                        execution.endTime(),
+                        execution.operator(),
+                        execution.result(),
+                        execution.log(),
+                        attachmentsByNode.getOrDefault(execution.nodeId(), List.of())
+                ))
+                .collect(Collectors.toList());
+
+        List<PlanNode> nodes = buildNodeTree(aggregate.nodes());
+
+        List<PlanActivity> activities = aggregate.activities().stream()
+                .sorted(Comparator.comparing(PlanActivityEntity::occurredAt)
+                        .thenComparing(PlanActivityEntity::activityId))
+                .map(activity -> new PlanActivity(
+                        activity.type(),
+                        activity.occurredAt(),
+                        activity.actor(),
+                        activity.message(),
+                        activity.referenceId(),
+                        activity.attributes()
+                ))
+                .collect(Collectors.toList());
+
+        List<PlanReminderRule> reminderRules = aggregate.reminderRules().stream()
+                .map(rule -> new PlanReminderRule(
+                        rule.ruleId(),
+                        rule.trigger(),
+                        rule.offsetMinutes(),
+                        rule.channels(),
+                        rule.templateId(),
+                        rule.recipients(),
+                        rule.description()
+                ))
+                .collect(Collectors.toList());
+
+        PlanReminderPolicy reminderPolicy = new PlanReminderPolicy(
+                reminderRules,
+                entity.reminderUpdatedAt(),
+                entity.reminderUpdatedBy()
+        );
+
+        return new Plan(
+                entity.id(),
+                entity.tenantId(),
+                entity.title(),
+                entity.description(),
+                entity.customerId(),
+                entity.owner(),
+                participants,
+                entity.status(),
+                entity.plannedStartTime(),
+                entity.plannedEndTime(),
+                entity.actualStartTime(),
+                entity.actualEndTime(),
+                entity.cancelReason(),
+                entity.canceledBy(),
+                entity.canceledAt(),
+                entity.timezone(),
+                nodes,
+                executions,
+                entity.createdAt(),
+                entity.updatedAt(),
+                activities,
+                reminderPolicy
+        );
+    }
+
+    private static void flattenNodes(String planId, List<PlanNode> nodes, String parentId, List<PlanNodeEntity> collector) {
+        if (nodes == null || nodes.isEmpty()) {
+            return;
+        }
+        for (PlanNode node : nodes) {
+            collector.add(new PlanNodeEntity(
+                    planId,
+                    node.getId(),
+                    parentId,
+                    node.getName(),
+                    node.getType(),
+                    node.getAssignee(),
+                    node.getOrder(),
+                    node.getExpectedDurationMinutes(),
+                    node.getActionRef(),
+                    node.getDescription()
+            ));
+            flattenNodes(planId, node.getChildren(), node.getId(), collector);
+        }
+    }
+
+    private static List<PlanNode> buildNodeTree(List<PlanNodeEntity> nodeEntities) {
+        if (nodeEntities == null || nodeEntities.isEmpty()) {
+            return List.of();
+        }
+        Map<String, List<PlanNodeEntity>> grouped = new HashMap<>();
+        for (PlanNodeEntity entity : nodeEntities) {
+            grouped.computeIfAbsent(entity.parentNodeId(), key -> new ArrayList<>()).add(entity);
+        }
+        for (List<PlanNodeEntity> entries : grouped.values()) {
+            entries.sort(Comparator.comparingInt(PlanNodeEntity::orderIndex));
+        }
+        return grouped.getOrDefault(null, List.of()).stream()
+                .sorted(Comparator.comparingInt(PlanNodeEntity::orderIndex))
+                .map(entity -> toDomainNode(entity, grouped))
+                .collect(Collectors.toList());
+    }
+
+    private static PlanNode toDomainNode(PlanNodeEntity entity, Map<String, List<PlanNodeEntity>> grouped) {
+        List<PlanNode> children = grouped.getOrDefault(entity.nodeId(), List.of()).stream()
+                .sorted(Comparator.comparingInt(PlanNodeEntity::orderIndex))
+                .map(child -> toDomainNode(child, grouped))
+                .collect(Collectors.toList());
+        return new PlanNode(
+                entity.nodeId(),
+                entity.name(),
+                entity.type(),
+                entity.assignee(),
+                entity.orderIndex(),
+                entity.expectedDurationMinutes(),
+                entity.actionRef(),
+                entity.description(),
+                children
+        );
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanReminderRuleEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanReminderRuleEntity.java
@@ -1,0 +1,22 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanReminderTrigger;
+
+import java.util.List;
+
+public record PlanReminderRuleEntity(
+        String planId,
+        String ruleId,
+        PlanReminderTrigger trigger,
+        int offsetMinutes,
+        List<String> channels,
+        String templateId,
+        List<String> recipients,
+        String description
+) {
+
+    public PlanReminderRuleEntity {
+        channels = channels == null ? List.of() : List.copyOf(channels);
+        recipients = recipients == null ? List.of() : List.copyOf(recipients);
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/plan/persistence/PlanPersistenceMapperTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/persistence/PlanPersistenceMapperTest.java
@@ -1,0 +1,136 @@
+package com.bob.mta.modules.plan.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanActivity;
+import com.bob.mta.modules.plan.domain.PlanActivityType;
+import com.bob.mta.modules.plan.domain.PlanNode;
+import com.bob.mta.modules.plan.domain.PlanNodeExecution;
+import com.bob.mta.modules.plan.domain.PlanNodeStatus;
+import com.bob.mta.modules.plan.domain.PlanReminderPolicy;
+import com.bob.mta.modules.plan.domain.PlanReminderRule;
+import com.bob.mta.modules.plan.domain.PlanReminderTrigger;
+import com.bob.mta.modules.plan.domain.PlanStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+class PlanPersistenceMapperTest {
+
+    @Test
+    void shouldConvertPlanRoundTrip() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        PlanNode childNode = new PlanNode(
+                "node-2",
+                "node-2-name",
+                "CHECK",
+                "assignee-2",
+                2,
+                30,
+                "action-2",
+                "description-2",
+                List.of()
+        );
+        PlanNode rootNode = new PlanNode(
+                "node-1",
+                "node-1-name",
+                "CHECK",
+                "assignee-1",
+                1,
+                60,
+                "action-1",
+                "description-1",
+                List.of(childNode)
+        );
+
+        PlanNodeExecution executionOne = new PlanNodeExecution(
+                "node-1",
+                PlanNodeStatus.DONE,
+                now.minusHours(2),
+                now.minusHours(1),
+                "operator-1",
+                "result-1",
+                "log-1",
+                List.of("file-1")
+        );
+        PlanNodeExecution executionTwo = new PlanNodeExecution(
+                "node-2",
+                PlanNodeStatus.PENDING,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of()
+        );
+
+        PlanActivity activity = new PlanActivity(
+                PlanActivityType.PLAN_CREATED,
+                now.minusDays(1),
+                "actor-1",
+                "message-1",
+                "reference-1",
+                Map.of("scope", "primary")
+        );
+
+        PlanReminderRule rule = new PlanReminderRule(
+                "rule-1",
+                PlanReminderTrigger.BEFORE_PLAN_START,
+                45,
+                List.of("EMAIL"),
+                "template-1",
+                List.of("OWNER"),
+                "description-1"
+        );
+        PlanReminderPolicy policy = new PlanReminderPolicy(List.of(rule), now.minusMinutes(10), "operator-2");
+
+        Plan plan = new Plan(
+                "plan-1",
+                "tenant-1",
+                "title-1",
+                "description-1",
+                "customer-1",
+                "owner-1",
+                List.of("owner-1", "participant-1"),
+                PlanStatus.IN_PROGRESS,
+                now.plusDays(1),
+                now.plusDays(1).plusHours(4),
+                now.minusHours(3),
+                now.minusHours(1),
+                null,
+                null,
+                null,
+                "Asia/Tokyo",
+                List.of(rootNode),
+                List.of(executionOne, executionTwo),
+                now.minusDays(2),
+                now,
+                List.of(activity),
+                policy
+        );
+
+        PlanAggregate aggregate = PlanPersistenceMapper.toAggregate(plan);
+        Plan converted = PlanPersistenceMapper.toDomain(aggregate);
+
+        assertThat(aggregate.plan().id()).isEqualTo("plan-1");
+        assertThat(aggregate.nodes()).hasSize(2);
+        assertThat(aggregate.executions()).hasSize(2);
+        assertThat(aggregate.activities()).hasSize(1);
+        assertThat(aggregate.reminderRules()).hasSize(1);
+
+        assertThat(converted.getId()).isEqualTo(plan.getId());
+        assertThat(converted.getTenantId()).isEqualTo(plan.getTenantId());
+        assertThat(converted.getTitle()).isEqualTo(plan.getTitle());
+        assertThat(converted.getParticipants()).containsExactlyElementsOf(plan.getParticipants());
+        assertThat(converted.getNodes()).hasSize(1);
+        assertThat(converted.getNodes().get(0).getChildren()).hasSize(1);
+        assertThat(converted.getExecutions()).hasSize(2);
+        assertThat(converted.getExecutions().get(0).getFileIds()).containsExactly("file-1");
+        assertThat(converted.getReminderPolicy().getRules()).hasSize(1);
+        assertThat(converted.getReminderPolicy().getUpdatedBy()).isEqualTo("operator-2");
+    }
+}


### PR DESCRIPTION
## Summary
- add plan persistence aggregate and record types covering plan core, nodes, reminders, and activities
- implement mapper utilities to convert between domain plans and persistence aggregates
- provide a round-trip unit test validating the mapping logic

## Testing
- `mvn test` *(fails: unable to resolve spring-boot-starter-parent from Maven Central, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d6a13698832f9e0731bc6e4c752c