### PR TITLE
feat: add plan persistence repository contract

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanActivityEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanActivityEntity.java
@@ -1,0 +1,22 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanActivityType;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+public record PlanActivityEntity(
+        String planId,
+        String activityId,
+        PlanActivityType type,
+        OffsetDateTime occurredAt,
+        String actor,
+        String message,
+        String referenceId,
+        Map<String, String> attributes
+) {
+
+    public PlanActivityEntity {
+        attributes = attributes == null ? Map.of() : Map.copyOf(attributes);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanAggregate.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanAggregate.java
@@ -1,0 +1,26 @@
+package com.bob.mta.modules.plan.persistence;
+
+import java.util.List;
+
+public record PlanAggregate(
+        PlanEntity plan,
+        List<PlanParticipantEntity> participants,
+        List<PlanNodeEntity> nodes,
+        List<PlanNodeExecutionEntity> executions,
+        List<PlanNodeAttachmentEntity> attachments,
+        List<PlanActivityEntity> activities,
+        List<PlanReminderRuleEntity> reminderRules
+) {
+
+    public PlanAggregate {
+        if (plan == null) {
+            throw new IllegalArgumentException("plan must not be null");
+        }
+        participants = participants == null ? List.of() : List.copyOf(participants);
+        nodes = nodes == null ? List.of() : List.copyOf(nodes);
+        executions = executions == null ? List.of() : List.copyOf(executions);
+        attachments = attachments == null ? List.of() : List.copyOf(attachments);
+        activities = activities == null ? List.of() : List.copyOf(activities);
+        reminderRules = reminderRules == null ? List.of() : List.copyOf(reminderRules);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanAggregateMapper.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanAggregateMapper.java
@@ -1,0 +1,63 @@
+package com.bob.mta.modules.plan.persistence;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Collection;
+import java.util.List;
+
+@Mapper
+public interface PlanAggregateMapper {
+
+    List<PlanEntity> findPlans(PlanQueryParameters parameters);
+
+    PlanEntity findPlanById(@Param("planId") String planId);
+
+    List<PlanParticipantEntity> findParticipantsByPlanIds(@Param("planIds") Collection<String> planIds);
+
+    List<PlanNodeEntity> findNodesByPlanIds(@Param("planIds") Collection<String> planIds);
+
+    List<PlanNodeExecutionEntity> findExecutionsByPlanIds(@Param("planIds") Collection<String> planIds);
+
+    List<PlanNodeAttachmentEntity> findAttachmentsByPlanIds(@Param("planIds") Collection<String> planIds);
+
+    List<PlanActivityEntity> findActivitiesByPlanIds(@Param("planIds") Collection<String> planIds);
+
+    List<PlanReminderRuleEntity> findReminderRulesByPlanIds(@Param("planIds") Collection<String> planIds);
+
+    void insertPlan(PlanEntity entity);
+
+    void updatePlan(PlanEntity entity);
+
+    void deletePlan(@Param("planId") String planId);
+
+    void deleteParticipants(@Param("planId") String planId);
+
+    void insertParticipants(@Param("participants") List<PlanParticipantEntity> participants);
+
+    void deleteNodes(@Param("planId") String planId);
+
+    void insertNodes(@Param("nodes") List<PlanNodeEntity> nodes);
+
+    void deleteExecutions(@Param("planId") String planId);
+
+    void insertExecutions(@Param("executions") List<PlanNodeExecutionEntity> executions);
+
+    void deleteAttachments(@Param("planId") String planId);
+
+    void insertAttachments(@Param("attachments") List<PlanNodeAttachmentEntity> attachments);
+
+    void deleteActivities(@Param("planId") String planId);
+
+    void insertActivities(@Param("activities") List<PlanActivityEntity> activities);
+
+    void deleteReminderRules(@Param("planId") String planId);
+
+    void insertReminderRules(@Param("rules") List<PlanReminderRuleEntity> rules);
+
+    String nextPlanId();
+
+    String nextNodeId();
+
+    String nextReminderId();
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanEntity.java
@@ -1,0 +1,28 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanStatus;
+
+import java.time.OffsetDateTime;
+
+public record PlanEntity(
+        String id,
+        String tenantId,
+        String customerId,
+        String owner,
+        String title,
+        String description,
+        PlanStatus status,
+        OffsetDateTime plannedStartTime,
+        OffsetDateTime plannedEndTime,
+        OffsetDateTime actualStartTime,
+        OffsetDateTime actualEndTime,
+        String cancelReason,
+        String canceledBy,
+        OffsetDateTime canceledAt,
+        String timezone,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt,
+        OffsetDateTime reminderUpdatedAt,
+        String reminderUpdatedBy
+) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeAttachmentEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeAttachmentEntity.java
@@ -1,0 +1,4 @@
+package com.bob.mta.modules.plan.persistence;
+
+public record PlanNodeAttachmentEntity(String planId, String nodeId, String fileId) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeEntity.java
@@ -1,0 +1,15 @@
+package com.bob.mta.modules.plan.persistence;
+
+public record PlanNodeEntity(
+        String planId,
+        String nodeId,
+        String parentNodeId,
+        String name,
+        String type,
+        String assignee,
+        int orderIndex,
+        Integer expectedDurationMinutes,
+        String actionRef,
+        String description
+) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeExecutionEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanNodeExecutionEntity.java
@@ -1,0 +1,17 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanNodeStatus;
+
+import java.time.OffsetDateTime;
+
+public record PlanNodeExecutionEntity(
+        String planId,
+        String nodeId,
+        PlanNodeStatus status,
+        OffsetDateTime startTime,
+        OffsetDateTime endTime,
+        String operator,
+        String result,
+        String log
+) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanParticipantEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanParticipantEntity.java
@@ -1,0 +1,4 @@
+package com.bob.mta.modules.plan.persistence;
+
+public record PlanParticipantEntity(String planId, String participantId) {
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanPersistenceMapper.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanPersistenceMapper.java
@@ -1,0 +1,246 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanActivity;
+import com.bob.mta.modules.plan.domain.PlanNode;
+import com.bob.mta.modules.plan.domain.PlanNodeExecution;
+import com.bob.mta.modules.plan.domain.PlanReminderPolicy;
+import com.bob.mta.modules.plan.domain.PlanReminderRule;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class PlanPersistenceMapper {
+
+    private PlanPersistenceMapper() {
+    }
+
+    public static PlanAggregate toAggregate(Plan plan) {
+        Objects.requireNonNull(plan, "plan");
+        PlanEntity planEntity = new PlanEntity(
+                plan.getId(),
+                plan.getTenantId(),
+                plan.getCustomerId(),
+                plan.getOwner(),
+                plan.getTitle(),
+                plan.getDescription(),
+                plan.getStatus(),
+                plan.getPlannedStartTime(),
+                plan.getPlannedEndTime(),
+                plan.getActualStartTime(),
+                plan.getActualEndTime(),
+                plan.getCancelReason(),
+                plan.getCanceledBy(),
+                plan.getCanceledAt(),
+                plan.getTimezone(),
+                plan.getCreatedAt(),
+                plan.getUpdatedAt(),
+                plan.getReminderPolicy().getUpdatedAt(),
+                plan.getReminderPolicy().getUpdatedBy()
+        );
+
+        List<PlanParticipantEntity> participants = plan.getParticipants().stream()
+                .map(participant -> new PlanParticipantEntity(plan.getId(), participant))
+                .collect(Collectors.toList());
+
+        List<PlanNodeEntity> nodeEntities = new ArrayList<>();
+        flattenNodes(plan.getId(), plan.getNodes(), null, nodeEntities);
+
+        List<PlanNodeExecutionEntity> executions = plan.getExecutions().stream()
+                .map(execution -> new PlanNodeExecutionEntity(
+                        plan.getId(),
+                        execution.getNodeId(),
+                        execution.getStatus(),
+                        execution.getStartTime(),
+                        execution.getEndTime(),
+                        execution.getOperator(),
+                        execution.getResult(),
+                        execution.getLog()
+                ))
+                .collect(Collectors.toList());
+
+        List<PlanNodeAttachmentEntity> attachments = plan.getExecutions().stream()
+                .flatMap(execution -> execution.getFileIds().stream()
+                        .map(fileId -> new PlanNodeAttachmentEntity(plan.getId(), execution.getNodeId(), fileId)))
+                .collect(Collectors.toList());
+
+        List<PlanActivityEntity> activities = new ArrayList<>();
+        List<PlanActivity> domainActivities = plan.getActivities();
+        for (int index = 0; index < domainActivities.size(); index++) {
+            PlanActivity activity = domainActivities.get(index);
+            String activityId = plan.getId() + "-activity-" + (index + 1);
+            activities.add(new PlanActivityEntity(
+                    plan.getId(),
+                    activityId,
+                    activity.getType(),
+                    activity.getOccurredAt(),
+                    activity.getActor(),
+                    activity.getMessage(),
+                    activity.getReferenceId(),
+                    activity.getAttributes()
+            ));
+        }
+
+        List<PlanReminderRuleEntity> reminderRules = plan.getReminderPolicy().getRules().stream()
+                .map(rule -> new PlanReminderRuleEntity(
+                        plan.getId(),
+                        rule.getId(),
+                        rule.getTrigger(),
+                        rule.getOffsetMinutes(),
+                        rule.getChannels(),
+                        rule.getTemplateId(),
+                        rule.getRecipients(),
+                        rule.getDescription()
+                ))
+                .collect(Collectors.toList());
+
+        return new PlanAggregate(planEntity, participants, nodeEntities, executions, attachments, activities, reminderRules);
+    }
+
+    public static Plan toDomain(PlanAggregate aggregate) {
+        Objects.requireNonNull(aggregate, "aggregate");
+        PlanEntity entity = aggregate.plan();
+
+        List<String> participants = aggregate.participants().stream()
+                .map(PlanParticipantEntity::participantId)
+                .collect(Collectors.toList());
+
+        Map<String, List<String>> attachmentsByNode = aggregate.attachments().stream()
+                .collect(Collectors.groupingBy(
+                        PlanNodeAttachmentEntity::nodeId,
+                        Collectors.mapping(PlanNodeAttachmentEntity::fileId, Collectors.toCollection(ArrayList::new))
+                ));
+
+        List<PlanNodeExecution> executions = aggregate.executions().stream()
+                .map(execution -> new PlanNodeExecution(
+                        execution.nodeId(),
+                        execution.status(),
+                        execution.startTime(),
+                        execution.endTime(),
+                        execution.operator(),
+                        execution.result(),
+                        execution.log(),
+                        attachmentsByNode.getOrDefault(execution.nodeId(), List.of())
+                ))
+                .collect(Collectors.toList());
+
+        List<PlanNode> nodes = buildNodeTree(aggregate.nodes());
+
+        List<PlanActivity> activities = aggregate.activities().stream()
+                .sorted(Comparator.comparing(PlanActivityEntity::occurredAt)
+                        .thenComparing(PlanActivityEntity::activityId))
+                .map(activity -> new PlanActivity(
+                        activity.type(),
+                        activity.occurredAt(),
+                        activity.actor(),
+                        activity.message(),
+                        activity.referenceId(),
+                        activity.attributes()
+                ))
+                .collect(Collectors.toList());
+
+        List<PlanReminderRule> reminderRules = aggregate.reminderRules().stream()
+                .map(rule -> new PlanReminderRule(
+                        rule.ruleId(),
+                        rule.trigger(),
+                        rule.offsetMinutes(),
+                        rule.channels(),
+                        rule.templateId(),
+                        rule.recipients(),
+                        rule.description()
+                ))
+                .collect(Collectors.toList());
+
+        PlanReminderPolicy reminderPolicy = new PlanReminderPolicy(
+                reminderRules,
+                entity.reminderUpdatedAt(),
+                entity.reminderUpdatedBy()
+        );
+
+        return new Plan(
+                entity.id(),
+                entity.tenantId(),
+                entity.title(),
+                entity.description(),
+                entity.customerId(),
+                entity.owner(),
+                participants,
+                entity.status(),
+                entity.plannedStartTime(),
+                entity.plannedEndTime(),
+                entity.actualStartTime(),
+                entity.actualEndTime(),
+                entity.cancelReason(),
+                entity.canceledBy(),
+                entity.canceledAt(),
+                entity.timezone(),
+                nodes,
+                executions,
+                entity.createdAt(),
+                entity.updatedAt(),
+                activities,
+                reminderPolicy
+        );
+    }
+
+    private static void flattenNodes(String planId, List<PlanNode> nodes, String parentId, List<PlanNodeEntity> collector) {
+        if (nodes == null || nodes.isEmpty()) {
+            return;
+        }
+        for (PlanNode node : nodes) {
+            collector.add(new PlanNodeEntity(
+                    planId,
+                    node.getId(),
+                    parentId,
+                    node.getName(),
+                    node.getType(),
+                    node.getAssignee(),
+                    node.getOrder(),
+                    node.getExpectedDurationMinutes(),
+                    node.getActionRef(),
+                    node.getDescription()
+            ));
+            flattenNodes(planId, node.getChildren(), node.getId(), collector);
+        }
+    }
+
+    private static List<PlanNode> buildNodeTree(List<PlanNodeEntity> nodeEntities) {
+        if (nodeEntities == null || nodeEntities.isEmpty()) {
+            return List.of();
+        }
+        Map<String, List<PlanNodeEntity>> grouped = new HashMap<>();
+        for (PlanNodeEntity entity : nodeEntities) {
+            grouped.computeIfAbsent(entity.parentNodeId(), key -> new ArrayList<>()).add(entity);
+        }
+        for (List<PlanNodeEntity> entries : grouped.values()) {
+            entries.sort(Comparator.comparingInt(PlanNodeEntity::orderIndex));
+        }
+        return grouped.getOrDefault(null, List.of()).stream()
+                .sorted(Comparator.comparingInt(PlanNodeEntity::orderIndex))
+                .map(entity -> toDomainNode(entity, grouped))
+                .collect(Collectors.toList());
+    }
+
+    private static PlanNode toDomainNode(PlanNodeEntity entity, Map<String, List<PlanNodeEntity>> grouped) {
+        List<PlanNode> children = grouped.getOrDefault(entity.nodeId(), List.of()).stream()
+                .sorted(Comparator.comparingInt(PlanNodeEntity::orderIndex))
+                .map(child -> toDomainNode(child, grouped))
+                .collect(Collectors.toList());
+        return new PlanNode(
+                entity.nodeId(),
+                entity.name(),
+                entity.type(),
+                entity.assignee(),
+                entity.orderIndex(),
+                entity.expectedDurationMinutes(),
+                entity.actionRef(),
+                entity.description(),
+                children
+        );
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanQueryParameters.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanQueryParameters.java
@@ -1,0 +1,40 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanStatus;
+import com.bob.mta.modules.plan.repository.PlanSearchCriteria;
+
+import java.time.OffsetDateTime;
+
+public record PlanQueryParameters(
+        String tenantId,
+        String customerId,
+        String owner,
+        String keyword,
+        PlanStatus status,
+        OffsetDateTime plannedStartFrom,
+        OffsetDateTime plannedEndTo,
+        Integer limit,
+        Integer offset
+) {
+
+    public static PlanQueryParameters empty() {
+        return new PlanQueryParameters(null, null, null, null, null, null, null, null, null);
+    }
+
+    public static PlanQueryParameters fromCriteria(PlanSearchCriteria criteria) {
+        if (criteria == null) {
+            return empty();
+        }
+        return new PlanQueryParameters(
+                criteria.getTenantId(),
+                criteria.getCustomerId(),
+                criteria.getOwner(),
+                criteria.getKeyword(),
+                criteria.getStatus(),
+                criteria.getFrom(),
+                criteria.getTo(),
+                null,
+                null
+        );
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanReminderRuleEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanReminderRuleEntity.java
@@ -1,0 +1,22 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanReminderTrigger;
+
+import java.util.List;
+
+public record PlanReminderRuleEntity(
+        String planId,
+        String ruleId,
+        PlanReminderTrigger trigger,
+        int offsetMinutes,
+        List<String> channels,
+        String templateId,
+        List<String> recipients,
+        String description
+) {
+
+    public PlanReminderRuleEntity {
+        channels = channels == null ? List.of() : List.copyOf(channels);
+        recipients = recipients == null ? List.of() : List.copyOf(recipients);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepository.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepository.java
@@ -1,0 +1,171 @@
+package com.bob.mta.modules.plan.repository;
+
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.persistence.PlanActivityEntity;
+import com.bob.mta.modules.plan.persistence.PlanAggregate;
+import com.bob.mta.modules.plan.persistence.PlanAggregateMapper;
+import com.bob.mta.modules.plan.persistence.PlanEntity;
+import com.bob.mta.modules.plan.persistence.PlanNodeAttachmentEntity;
+import com.bob.mta.modules.plan.persistence.PlanNodeEntity;
+import com.bob.mta.modules.plan.persistence.PlanNodeExecutionEntity;
+import com.bob.mta.modules.plan.persistence.PlanParticipantEntity;
+import com.bob.mta.modules.plan.persistence.PlanPersistenceMapper;
+import com.bob.mta.modules.plan.persistence.PlanQueryParameters;
+import com.bob.mta.modules.plan.persistence.PlanReminderRuleEntity;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Repository
+@ConditionalOnBean(PlanAggregateMapper.class)
+public class PlanPersistencePlanRepository implements PlanRepository {
+
+    private final PlanAggregateMapper mapper;
+
+    public PlanPersistencePlanRepository(PlanAggregateMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<Plan> findAll() {
+        return toDomain(loadAggregates(mapper.findPlans(PlanQueryParameters.empty())));
+    }
+
+    @Override
+    public List<Plan> findByCriteria(PlanSearchCriteria criteria) {
+        PlanQueryParameters parameters = PlanQueryParameters.fromCriteria(criteria);
+        return toDomain(loadAggregates(mapper.findPlans(parameters)));
+    }
+
+    @Override
+    public Optional<Plan> findById(String id) {
+        PlanEntity entity = mapper.findPlanById(id);
+        if (entity == null) {
+            return Optional.empty();
+        }
+        List<Plan> plans = toDomain(loadAggregates(List.of(entity)));
+        return plans.isEmpty() ? Optional.empty() : Optional.of(plans.get(0));
+    }
+
+    @Override
+    public void save(Plan plan) {
+        Objects.requireNonNull(plan, "plan");
+        PlanAggregate aggregate = PlanPersistenceMapper.toAggregate(plan);
+        boolean exists = mapper.findPlanById(plan.getId()) != null;
+        if (exists) {
+            mapper.updatePlan(aggregate.plan());
+            cleanupAssociations(plan.getId());
+        } else {
+            mapper.insertPlan(aggregate.plan());
+        }
+        persistAssociations(aggregate);
+    }
+
+    @Override
+    public void delete(String id) {
+        Objects.requireNonNull(id, "id");
+        cleanupAssociations(id);
+        mapper.deletePlan(id);
+    }
+
+    @Override
+    public String nextPlanId() {
+        return mapper.nextPlanId();
+    }
+
+    @Override
+    public String nextNodeId() {
+        return mapper.nextNodeId();
+    }
+
+    @Override
+    public String nextReminderId() {
+        return mapper.nextReminderId();
+    }
+
+    private void persistAssociations(PlanAggregate aggregate) {
+        if (!aggregate.participants().isEmpty()) {
+            mapper.insertParticipants(new ArrayList<>(aggregate.participants()));
+        }
+        if (!aggregate.nodes().isEmpty()) {
+            mapper.insertNodes(new ArrayList<>(aggregate.nodes()));
+        }
+        if (!aggregate.executions().isEmpty()) {
+            mapper.insertExecutions(new ArrayList<>(aggregate.executions()));
+        }
+        if (!aggregate.attachments().isEmpty()) {
+            mapper.insertAttachments(new ArrayList<>(aggregate.attachments()));
+        }
+        if (!aggregate.activities().isEmpty()) {
+            mapper.insertActivities(new ArrayList<>(aggregate.activities()));
+        }
+        if (!aggregate.reminderRules().isEmpty()) {
+            mapper.insertReminderRules(new ArrayList<>(aggregate.reminderRules()));
+        }
+    }
+
+    private void cleanupAssociations(String planId) {
+        mapper.deleteAttachments(planId);
+        mapper.deleteExecutions(planId);
+        mapper.deleteNodes(planId);
+        mapper.deleteParticipants(planId);
+        mapper.deleteActivities(planId);
+        mapper.deleteReminderRules(planId);
+    }
+
+    private List<PlanAggregate> loadAggregates(List<PlanEntity> planEntities) {
+        if (planEntities == null || planEntities.isEmpty()) {
+            return List.of();
+        }
+        List<String> planIds = planEntities.stream().map(PlanEntity::id).toList();
+        Map<String, List<PlanParticipantEntity>> participants = groupByPlanId(
+                mapper.findParticipantsByPlanIds(planIds), PlanParticipantEntity::planId);
+        Map<String, List<PlanNodeEntity>> nodes = groupByPlanId(
+                mapper.findNodesByPlanIds(planIds), PlanNodeEntity::planId);
+        Map<String, List<PlanNodeExecutionEntity>> executions = groupByPlanId(
+                mapper.findExecutionsByPlanIds(planIds), PlanNodeExecutionEntity::planId);
+        Map<String, List<PlanNodeAttachmentEntity>> attachments = groupByPlanId(
+                mapper.findAttachmentsByPlanIds(planIds), PlanNodeAttachmentEntity::planId);
+        Map<String, List<PlanActivityEntity>> activities = groupByPlanId(
+                mapper.findActivitiesByPlanIds(planIds), PlanActivityEntity::planId);
+        Map<String, List<PlanReminderRuleEntity>> reminderRules = groupByPlanId(
+                mapper.findReminderRulesByPlanIds(planIds), PlanReminderRuleEntity::planId);
+
+        return planEntities.stream()
+                .sorted(Comparator.comparing(PlanEntity::createdAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(entity -> new PlanAggregate(
+                        entity,
+                        participants.getOrDefault(entity.id(), List.of()),
+                        nodes.getOrDefault(entity.id(), List.of()),
+                        executions.getOrDefault(entity.id(), List.of()),
+                        attachments.getOrDefault(entity.id(), List.of()),
+                        activities.getOrDefault(entity.id(), List.of()),
+                        reminderRules.getOrDefault(entity.id(), List.of())
+                ))
+                .toList();
+    }
+
+    private <T> Map<String, List<T>> groupByPlanId(List<T> items, Function<T, String> classifier) {
+        if (items == null || items.isEmpty()) {
+            return Map.of();
+        }
+        return items.stream().collect(Collectors.groupingBy(classifier));
+    }
+
+    private List<Plan> toDomain(List<PlanAggregate> aggregates) {
+        if (aggregates.isEmpty()) {
+            return List.of();
+        }
+        return aggregates.stream()
+                .map(PlanPersistenceMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/plan/persistence/PlanPersistenceMapperTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/persistence/PlanPersistenceMapperTest.java
@@ -1,0 +1,136 @@
+package com.bob.mta.modules.plan.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanActivity;
+import com.bob.mta.modules.plan.domain.PlanActivityType;
+import com.bob.mta.modules.plan.domain.PlanNode;
+import com.bob.mta.modules.plan.domain.PlanNodeExecution;
+import com.bob.mta.modules.plan.domain.PlanNodeStatus;
+import com.bob.mta.modules.plan.domain.PlanReminderPolicy;
+import com.bob.mta.modules.plan.domain.PlanReminderRule;
+import com.bob.mta.modules.plan.domain.PlanReminderTrigger;
+import com.bob.mta.modules.plan.domain.PlanStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+class PlanPersistenceMapperTest {
+
+    @Test
+    void shouldConvertPlanRoundTrip() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        PlanNode childNode = new PlanNode(
+                "node-2",
+                "node-2-name",
+                "CHECK",
+                "assignee-2",
+                2,
+                30,
+                "action-2",
+                "description-2",
+                List.of()
+        );
+        PlanNode rootNode = new PlanNode(
+                "node-1",
+                "node-1-name",
+                "CHECK",
+                "assignee-1",
+                1,
+                60,
+                "action-1",
+                "description-1",
+                List.of(childNode)
+        );
+
+        PlanNodeExecution executionOne = new PlanNodeExecution(
+                "node-1",
+                PlanNodeStatus.DONE,
+                now.minusHours(2),
+                now.minusHours(1),
+                "operator-1",
+                "result-1",
+                "log-1",
+                List.of("file-1")
+        );
+        PlanNodeExecution executionTwo = new PlanNodeExecution(
+                "node-2",
+                PlanNodeStatus.PENDING,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of()
+        );
+
+        PlanActivity activity = new PlanActivity(
+                PlanActivityType.PLAN_CREATED,
+                now.minusDays(1),
+                "actor-1",
+                "message-1",
+                "reference-1",
+                Map.of("scope", "primary")
+        );
+
+        PlanReminderRule rule = new PlanReminderRule(
+                "rule-1",
+                PlanReminderTrigger.BEFORE_PLAN_START,
+                45,
+                List.of("EMAIL"),
+                "template-1",
+                List.of("OWNER"),
+                "description-1"
+        );
+        PlanReminderPolicy policy = new PlanReminderPolicy(List.of(rule), now.minusMinutes(10), "operator-2");
+
+        Plan plan = new Plan(
+                "plan-1",
+                "tenant-1",
+                "title-1",
+                "description-1",
+                "customer-1",
+                "owner-1",
+                List.of("owner-1", "participant-1"),
+                PlanStatus.IN_PROGRESS,
+                now.plusDays(1),
+                now.plusDays(1).plusHours(4),
+                now.minusHours(3),
+                now.minusHours(1),
+                null,
+                null,
+                null,
+                "Asia/Tokyo",
+                List.of(rootNode),
+                List.of(executionOne, executionTwo),
+                now.minusDays(2),
+                now,
+                List.of(activity),
+                policy
+        );
+
+        PlanAggregate aggregate = PlanPersistenceMapper.toAggregate(plan);
+        Plan converted = PlanPersistenceMapper.toDomain(aggregate);
+
+        assertThat(aggregate.plan().id()).isEqualTo("plan-1");
+        assertThat(aggregate.nodes()).hasSize(2);
+        assertThat(aggregate.executions()).hasSize(2);
+        assertThat(aggregate.activities()).hasSize(1);
+        assertThat(aggregate.reminderRules()).hasSize(1);
+
+        assertThat(converted.getId()).isEqualTo(plan.getId());
+        assertThat(converted.getTenantId()).isEqualTo(plan.getTenantId());
+        assertThat(converted.getTitle()).isEqualTo(plan.getTitle());
+        assertThat(converted.getParticipants()).containsExactlyElementsOf(plan.getParticipants());
+        assertThat(converted.getNodes()).hasSize(1);
+        assertThat(converted.getNodes().get(0).getChildren()).hasSize(1);
+        assertThat(converted.getExecutions()).hasSize(2);
+        assertThat(converted.getExecutions().get(0).getFileIds()).containsExactly("file-1");
+        assertThat(converted.getReminderPolicy().getRules()).hasSize(1);
+        assertThat(converted.getReminderPolicy().getUpdatedBy()).isEqualTo("operator-2");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepositoryTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepositoryTest.java
@@ -1,0 +1,270 @@
+package com.bob.mta.modules.plan.repository;
+
+import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanActivity;
+import com.bob.mta.modules.plan.domain.PlanActivityType;
+import com.bob.mta.modules.plan.domain.PlanNode;
+import com.bob.mta.modules.plan.domain.PlanNodeExecution;
+import com.bob.mta.modules.plan.domain.PlanNodeStatus;
+import com.bob.mta.modules.plan.domain.PlanReminderPolicy;
+import com.bob.mta.modules.plan.domain.PlanReminderRule;
+import com.bob.mta.modules.plan.domain.PlanReminderTrigger;
+import com.bob.mta.modules.plan.domain.PlanStatus;
+import com.bob.mta.modules.plan.persistence.PlanAggregate;
+import com.bob.mta.modules.plan.persistence.PlanAggregateMapper;
+import com.bob.mta.modules.plan.persistence.PlanEntity;
+import com.bob.mta.modules.plan.persistence.PlanPersistenceMapper;
+import com.bob.mta.modules.plan.repository.PlanSearchCriteria;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlanPersistencePlanRepositoryTest {
+
+    @Mock
+    private PlanAggregateMapper mapper;
+
+    @InjectMocks
+    private PlanPersistencePlanRepository repository;
+
+    @Captor
+    private ArgumentCaptor<List<?>> listCaptor;
+
+    private Plan samplePlan;
+    private PlanAggregate aggregate;
+
+    @BeforeEach
+    void setUp() {
+        samplePlan = buildSamplePlan();
+        aggregate = PlanPersistenceMapper.toAggregate(samplePlan);
+    }
+
+    @Test
+    void shouldLoadPlanById() {
+        when(mapper.findPlanById("plan-1")).thenReturn(aggregate.plan());
+        when(mapper.findParticipantsByPlanIds(List.of("plan-1"))).thenReturn(aggregate.participants());
+        when(mapper.findNodesByPlanIds(List.of("plan-1"))).thenReturn(aggregate.nodes());
+        when(mapper.findExecutionsByPlanIds(List.of("plan-1"))).thenReturn(aggregate.executions());
+        when(mapper.findAttachmentsByPlanIds(List.of("plan-1"))).thenReturn(aggregate.attachments());
+        when(mapper.findActivitiesByPlanIds(List.of("plan-1"))).thenReturn(aggregate.activities());
+        when(mapper.findReminderRulesByPlanIds(List.of("plan-1"))).thenReturn(aggregate.reminderRules());
+
+        Optional<Plan> result = repository.findById("plan-1");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo("plan-1");
+        assertThat(result.get().getNodes()).hasSize(1);
+        verify(mapper).findPlanById("plan-1");
+        verify(mapper).findParticipantsByPlanIds(List.of("plan-1"));
+        verify(mapper).findNodesByPlanIds(List.of("plan-1"));
+        verify(mapper).findExecutionsByPlanIds(List.of("plan-1"));
+        verify(mapper).findAttachmentsByPlanIds(List.of("plan-1"));
+        verify(mapper).findActivitiesByPlanIds(List.of("plan-1"));
+        verify(mapper).findReminderRulesByPlanIds(List.of("plan-1"));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenPlanNotFound() {
+        when(mapper.findPlanById("missing")).thenReturn(null);
+
+        Optional<Plan> result = repository.findById("missing");
+
+        assertThat(result).isEmpty();
+        verify(mapper).findPlanById("missing");
+        verifyNoMoreInteractions(mapper);
+    }
+
+    @Test
+    void shouldSaveNewPlan() {
+        when(mapper.findPlanById("plan-1")).thenReturn(null);
+
+        repository.save(samplePlan);
+
+        verify(mapper).insertPlan(aggregate.plan());
+        verify(mapper, never()).updatePlan(any());
+        verify(mapper).insertParticipants(listCaptor.capture());
+        assertThat(listCaptor.getValue()).hasSize(2);
+        verify(mapper).insertNodes(any());
+        verify(mapper).insertExecutions(any());
+        verify(mapper).insertAttachments(any());
+        verify(mapper).insertActivities(any());
+        verify(mapper).insertReminderRules(any());
+    }
+
+    @Test
+    void shouldUpdateExistingPlan() {
+        PlanEntity existing = aggregate.plan();
+        when(mapper.findPlanById("plan-1")).thenReturn(existing);
+
+        repository.save(samplePlan);
+
+        verify(mapper).updatePlan(existing);
+        verify(mapper).deleteAttachments("plan-1");
+        verify(mapper).deleteExecutions("plan-1");
+        verify(mapper).deleteNodes("plan-1");
+        verify(mapper).deleteParticipants("plan-1");
+        verify(mapper).deleteActivities("plan-1");
+        verify(mapper).deleteReminderRules("plan-1");
+        verify(mapper).insertParticipants(any());
+        verify(mapper).insertNodes(any());
+        verify(mapper).insertExecutions(any());
+        verify(mapper).insertAttachments(any());
+        verify(mapper).insertActivities(any());
+        verify(mapper).insertReminderRules(any());
+    }
+
+    @Test
+    void shouldDeletePlan() {
+        repository.delete("plan-1");
+
+        verify(mapper).deleteAttachments("plan-1");
+        verify(mapper).deleteExecutions("plan-1");
+        verify(mapper).deleteNodes("plan-1");
+        verify(mapper).deleteParticipants("plan-1");
+        verify(mapper).deleteActivities("plan-1");
+        verify(mapper).deleteReminderRules("plan-1");
+        verify(mapper).deletePlan("plan-1");
+    }
+
+    @Test
+    void shouldFindPlansByCriteria() {
+        when(mapper.findPlans(any())).thenReturn(List.of(aggregate.plan()));
+        when(mapper.findParticipantsByPlanIds(List.of("plan-1"))).thenReturn(aggregate.participants());
+        when(mapper.findNodesByPlanIds(List.of("plan-1"))).thenReturn(aggregate.nodes());
+        when(mapper.findExecutionsByPlanIds(List.of("plan-1"))).thenReturn(aggregate.executions());
+        when(mapper.findAttachmentsByPlanIds(List.of("plan-1"))).thenReturn(aggregate.attachments());
+        when(mapper.findActivitiesByPlanIds(List.of("plan-1"))).thenReturn(aggregate.activities());
+        when(mapper.findReminderRulesByPlanIds(List.of("plan-1"))).thenReturn(aggregate.reminderRules());
+
+        List<Plan> plans = repository.findByCriteria(PlanSearchCriteria.builder()
+                .tenantId("tenant-1")
+                .status(PlanStatus.IN_PROGRESS)
+                .build());
+
+        assertThat(plans).hasSize(1);
+        verify(mapper).findPlans(any());
+        verify(mapper).findParticipantsByPlanIds(List.of("plan-1"));
+        verify(mapper).findNodesByPlanIds(List.of("plan-1"));
+        verify(mapper).findExecutionsByPlanIds(List.of("plan-1"));
+        verify(mapper).findAttachmentsByPlanIds(List.of("plan-1"));
+        verify(mapper).findActivitiesByPlanIds(List.of("plan-1"));
+        verify(mapper).findReminderRulesByPlanIds(List.of("plan-1"));
+    }
+
+    @Test
+    void shouldProvideSequenceDelegation() {
+        when(mapper.nextPlanId()).thenReturn("PLAN-100");
+        when(mapper.nextNodeId()).thenReturn("NODE-200");
+        when(mapper.nextReminderId()).thenReturn("REM-300");
+
+        assertThat(repository.nextPlanId()).isEqualTo("PLAN-100");
+        assertThat(repository.nextNodeId()).isEqualTo("NODE-200");
+        assertThat(repository.nextReminderId()).isEqualTo("REM-300");
+    }
+
+    private Plan buildSamplePlan() {
+        OffsetDateTime now = OffsetDateTime.now();
+        PlanNode childNode = new PlanNode(
+                "node-2",
+                "node-2-name",
+                "CHECK",
+                "assignee-2",
+                2,
+                30,
+                "action-2",
+                "description-2",
+                List.of()
+        );
+        PlanNode rootNode = new PlanNode(
+                "node-1",
+                "node-1-name",
+                "CHECK",
+                "assignee-1",
+                1,
+                60,
+                "action-1",
+                "description-1",
+                List.of(childNode)
+        );
+        PlanNodeExecution executionOne = new PlanNodeExecution(
+                "node-1",
+                PlanNodeStatus.DONE,
+                now.minusHours(2),
+                now.minusHours(1),
+                "operator-1",
+                "result-1",
+                "log-1",
+                List.of("file-1")
+        );
+        PlanNodeExecution executionTwo = new PlanNodeExecution(
+                "node-2",
+                PlanNodeStatus.PENDING,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of()
+        );
+        PlanActivity activity = new PlanActivity(
+                PlanActivityType.PLAN_CREATED,
+                now.minusDays(1),
+                "actor-1",
+                "message-1",
+                "reference-1",
+                Map.of("scope", "primary")
+        );
+        PlanReminderRule rule = new PlanReminderRule(
+                "rule-1",
+                PlanReminderTrigger.BEFORE_PLAN_START,
+                45,
+                List.of("EMAIL"),
+                "template-1",
+                List.of("OWNER"),
+                "description-1"
+        );
+        PlanReminderPolicy policy = new PlanReminderPolicy(List.of(rule), now.minusMinutes(10), "operator-2");
+        return new Plan(
+                "plan-1",
+                "tenant-1",
+                "title-1",
+                "description-1",
+                "customer-1",
+                "owner-1",
+                List.of("owner-1", "participant-1"),
+                PlanStatus.IN_PROGRESS,
+                now.plusDays(1),
+                now.plusDays(1).plusHours(4),
+                now.minusHours(3),
+                now.minusHours(1),
+                null,
+                null,
+                null,
+                "Asia/Tokyo",
+                List.of(rootNode),
+                List.of(executionOne, executionTwo),
+                now.minusDays(2),
+                now,
+                List.of(activity),
+                policy
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- introduce persistence query parameters and MyBatis mapper contract for plan aggregates
- provide a conditional PlanRepository implementation that persists aggregates through the new mapper
- cover the repository orchestration logic with unit tests using mocked persistence operations

## Testing
- `mvn test` *(fails: unable to download spring-boot-starter-parent 3.2.5 from Maven Central, HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d6a13698832f9e0731bc6e4c752c