### PR TITLE
Configure plan persistence data source and add integration tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -79,6 +79,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
     username: bobmta
     password: change-me
     driver-class-name: org.postgresql.Driver
+  transaction:
+    default-timeout: 30s
   jackson:
     serialization:
       write-dates-as-timestamps: false
@@ -20,6 +22,8 @@ spring:
     init:
       platform: postgresql
       mode: never
+mybatis:
+  mapper-locations: classpath:/mapper/*.xml
 server:
   port: 8080
 management:


### PR DESCRIPTION
## Summary
- configure plan persistence to supply DataSource, transaction manager, JDBC template, and type handler registration when datasource properties are provided
- document mapper locations and transaction defaults in application configuration
- add a Testcontainers-based integration test covering PlanPersistencePlanRepository CRUD flows, pagination parity with the in-memory repository, and identifier generation

## Testing
- mvn -q -DskipTests=false test *(fails: cannot download Spring Boot parent from Maven Central due to 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db5d56dd00832f93c5dc148dfa78e4