### PR TITLE
Add docker compose deployment stack and deployment docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ backend/target/
 
 # OS
 .DS_Store
+
+deploy/postgres/data/
+deploy/minio/data/
+deploy/certs/*.pem

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,11 @@
+# 部署资源概览
+
+该目录与设计说明书中的 Docker Compose 拓扑保持一致，提供以下示例文件：
+
+- `nginx/default.conf`：前端静态站点容器使用的 Nginx 配置，负责托管 `frontend/dist` 并将 `/api/` 请求代理到后端。
+- `nginx/reverse-proxy.conf`：可选的边缘 Nginx 反向代理，统一 80/443 端口并加载 `deploy/certs` 中的 TLS 证书。
+- `backend/Dockerfile` 与 `backend/backend.env`：构建后端镜像及其默认环境变量。
+- `minio/README.md`：MinIO 初始化及数据卷说明。
+- `certs/README.md`：证书挂载说明，指引在生产环境放置 `fullchain.pem`/`privkey.pem`。
+
+Compose 运行时会将数据库与对象存储的数据挂载到 `deploy/postgres/data`、`deploy/minio/data`，请根据安全策略调整挂载路径并妥善备份。

--- a/deploy/backend/Dockerfile
+++ b/deploy/backend/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+FROM maven:3.9.6-eclipse-temurin-17 AS builder
+WORKDIR /workspace
+COPY backend/pom.xml backend/pom.xml
+RUN --mount=type=cache,target=/root/.m2 mvn -f backend/pom.xml dependency:go-offline
+COPY backend/src backend/src
+RUN --mount=type=cache,target=/root/.m2 mvn -f backend/pom.xml -DskipTests package
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=builder /workspace/backend/target/backend-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/deploy/backend/README.md
+++ b/deploy/backend/README.md
@@ -1,0 +1,8 @@
+# 后端容器配置
+
+本目录包含：
+
+- `Dockerfile`：基于 Maven 多阶段构建 `backend` 模块并产出可运行的 Spring Boot 镜像。
+- `backend.env`：示例环境变量文件，供 `docker-compose.yml` 读取数据库、JWT 和 MinIO 的默认配置。
+
+根据部署环境需求，可复制 `backend.env` 为本地 `.env` 并替换敏感信息。Compose 会将变量注入后端容器，同时复用数据库和 MinIO 容器的同名变量，保持凭证一致。

--- a/deploy/backend/backend.env
+++ b/deploy/backend/backend.env
@@ -1,0 +1,14 @@
+# Common environment defaults for the docker-compose stack.
+# Override the values in a secure .env file when deploying to production.
+
+POSTGRES_DB=bobmta
+POSTGRES_USER=bobmta
+POSTGRES_PASSWORD=change-me
+
+JWT_ACCESS_TOKEN_SECRET=change-me-please
+
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
+MINIO_BUCKET=plan-files
+
+TZ=Asia/Tokyo

--- a/deploy/certs/README.md
+++ b/deploy/certs/README.md
@@ -1,0 +1,8 @@
+# TLS 证书占位
+
+将生产环境的证书文件放在此目录中并保持以下文件名，以便 docker-compose 中的 `nginx` 代理容器能够加载：
+
+- `fullchain.pem`：包含服务器证书和中间证书链。
+- `privkey.pem`：服务器私钥。
+
+建议通过 `.gitignore` 忽略真实证书文件，仅在部署环境中挂载。开发或测试阶段若不启用 TLS，可保持该目录为空，并在运行 Compose 时跳过 `proxy` profile。

--- a/deploy/minio/README.md
+++ b/deploy/minio/README.md
@@ -1,0 +1,12 @@
+# MinIO 配置说明
+
+`docker-compose.yml` 默认以 `minio/minio` 镜像启动对象存储，并将数据目录挂载到 `deploy/minio/data`。首次启动后可通过浏览器访问 `http://localhost:9001`，使用 `.env` 中的 `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` 登录控制台并创建业务桶。
+
+示例中 `deploy/backend/backend.env` 预置桶名为 `plan-files`，可手动在控制台或使用 MinIO Client（`mc`）创建：
+
+```bash
+mc alias set bobmta http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+mc mb bobmta/plan-files
+```
+
+生产环境请修改凭证，并考虑关闭控制台端口或在外部反向代理中添加访问控制。

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://api:8080/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /assets/ {
+        expires 1h;
+        add_header Cache-Control "public";
+    }
+}

--- a/deploy/nginx/reverse-proxy.conf
+++ b/deploy/nginx/reverse-proxy.conf
@@ -1,0 +1,69 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    upstream bobmta_web {
+        server web:80;
+    }
+
+    upstream bobmta_api {
+        server api:8080;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate     /etc/nginx/certs/fullchain.pem;
+        ssl_certificate_key /etc/nginx/certs/privkey.pem;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 10m;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+
+        location / {
+            proxy_pass http://bobmta_web;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api/ {
+            proxy_pass http://bobmta_api/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /healthz {
+            proxy_pass http://bobmta_api/actuator/health;
+        }
+    }
+}

--- a/deploy/postgres/README.md
+++ b/deploy/postgres/README.md
@@ -1,0 +1,5 @@
+# PostgreSQL 数据卷
+
+`docker-compose.yml` 会把数据库数据目录挂载到 `deploy/postgres/data`。若需要持久化或备份，可将该目录映射到宿主机其他位置，并确保权限允许 `postgres` 用户写入。
+
+生产环境请修改 `POSTGRES_PASSWORD`，并根据需要在 `backend/backend.env` 或单独的 `.env` 文件中覆盖数据库名称与账号。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+version: "3.9"
+
+services:
+  web:
+    image: nginx:1.25-alpine
+    container_name: bobmta_web
+    depends_on:
+      - api
+    ports:
+      - "8080:80"
+    volumes:
+      - ./frontend/dist:/usr/share/nginx/html:ro
+      - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    restart: unless-stopped
+
+  api:
+    build:
+      context: .
+      dockerfile: deploy/backend/Dockerfile
+    container_name: bobmta_api
+    env_file:
+      - deploy/backend/backend.env
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/${POSTGRES_DB:-bobmta}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-bobmta}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
+      JWT_ACCESS_TOKEN_SECRET: ${JWT_ACCESS_TOKEN_SECRET:-change-me-please}
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_BUCKET: ${MINIO_BUCKET:-plan-files}
+      TZ: ${TZ:-Asia/Tokyo}
+    depends_on:
+      db:
+        condition: service_started
+      minio:
+        condition: service_started
+    ports:
+      - "8081:8080"
+    restart: unless-stopped
+
+  db:
+    image: postgres:15-alpine
+    container_name: bobmta_db
+    env_file:
+      - deploy/backend/backend.env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-bobmta}
+      POSTGRES_USER: ${POSTGRES_USER:-bobmta}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
+      TZ: ${TZ:-Asia/Tokyo}
+    volumes:
+      - ./deploy/postgres/data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:RELEASE.2024-01-29T23-21-55Z
+    container_name: bobmta_minio
+    command: server /data --console-address ":9001"
+    env_file:
+      - deploy/backend/backend.env
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      TZ: ${TZ:-Asia/Tokyo}
+    volumes:
+      - ./deploy/minio/data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.25-alpine
+    container_name: bobmta_gateway
+    depends_on:
+      - web
+      - api
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./deploy/nginx/reverse-proxy.conf:/etc/nginx/nginx.conf:ro
+      - ./deploy/certs:/etc/nginx/certs:ro
+    restart: unless-stopped
+    profiles:
+      - proxy


### PR DESCRIPTION
## Summary
- add a docker-compose stack that builds the backend image and wires frontend, PostgreSQL, MinIO and an optional TLS proxy
- provide deploy/ examples for nginx configs, backend env defaults, MinIO/PostgreSQL data notes and TLS certificate guidance
- extend the README with one-click compose deployment instructions and ignore generated data folders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db9eadcc28832f9950668f5c3b8cdc