### PR TITLE
Add MinIO-backed file storage integration and tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,6 +27,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>8.5.7</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/backend/src/main/java/com/bob/mta/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/bob/mta/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     USER_INACTIVE(4032, "user.inactive"),
     NOT_FOUND(4040, "resource.not_found"),
     USER_NOT_FOUND(4041, "user.not_found"),
+    FILE_NOT_FOUND(4045, "file.not_found"),
     CONFLICT(4090, "operation.conflict"),
     USERNAME_EXISTS(4091, "user.username_exists"),
     EMAIL_EXISTS(4092, "user.email_exists"),

--- a/backend/src/main/java/com/bob/mta/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/bob/mta/common/exception/GlobalExceptionHandler.java
@@ -63,7 +63,7 @@ public class GlobalExceptionHandler {
             case BAD_REQUEST, ACTIVATION_TOKEN_INVALID, ACTIVATION_TOKEN_EXPIRED -> HttpStatus.BAD_REQUEST;
             case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
             case FORBIDDEN, USER_INACTIVE -> HttpStatus.FORBIDDEN;
-            case NOT_FOUND, USER_NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case NOT_FOUND, USER_NOT_FOUND, FILE_NOT_FOUND -> HttpStatus.NOT_FOUND;
             case CONFLICT, USERNAME_EXISTS, EMAIL_EXISTS, USER_ALREADY_ACTIVE -> HttpStatus.CONFLICT;
             case INTERNAL_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR;
             default -> HttpStatus.INTERNAL_SERVER_ERROR;

--- a/backend/src/main/java/com/bob/mta/modules/file/config/FileServiceConfiguration.java
+++ b/backend/src/main/java/com/bob/mta/modules/file/config/FileServiceConfiguration.java
@@ -1,0 +1,51 @@
+package com.bob.mta.modules.file.config;
+
+import com.bob.mta.modules.file.service.FileService;
+import com.bob.mta.modules.file.service.impl.InMemoryFileService;
+import com.bob.mta.modules.file.service.impl.MinioFileService;
+import io.minio.MinioClient;
+import java.time.Duration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@EnableConfigurationProperties(FileStorageProperties.class)
+public class FileServiceConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "app.file", name = "storage", havingValue = "IN_MEMORY", matchIfMissing = true)
+    public FileService inMemoryFileService() {
+        return new InMemoryFileService();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "app.file", name = "storage", havingValue = "MINIO")
+    public MinioClient minioClient(FileStorageProperties properties) {
+        FileStorageProperties.MinioProperties minio = properties.getMinio();
+        if (!StringUtils.hasText(minio.getEndpoint())) {
+            throw new IllegalStateException("MinIO endpoint must be configured when storage is MINIO");
+        }
+        if (!StringUtils.hasText(minio.getAccessKey()) || !StringUtils.hasText(minio.getSecretKey())) {
+            throw new IllegalStateException("MinIO credentials must be configured when storage is MINIO");
+        }
+        return MinioClient.builder()
+                .endpoint(minio.getEndpoint())
+                .credentials(minio.getAccessKey(), minio.getSecretKey())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "app.file", name = "storage", havingValue = "MINIO")
+    public FileService minioFileService(MinioClient minioClient, FileStorageProperties properties) {
+        int expirySeconds = properties.getMinio().getDownloadExpirySeconds();
+        if (expirySeconds <= 0) {
+            throw new IllegalStateException("MinIO presigned URL expiry must be positive");
+        }
+        long maxSupported = Duration.ofDays(7).getSeconds();
+        int boundedExpiry = (int) Math.min(expirySeconds, maxSupported);
+        return new MinioFileService(minioClient, Duration.ofSeconds(boundedExpiry));
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/file/config/FileStorageProperties.java
+++ b/backend/src/main/java/com/bob/mta/modules/file/config/FileStorageProperties.java
@@ -1,0 +1,66 @@
+package com.bob.mta.modules.file.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.file")
+public class FileStorageProperties {
+
+    private String storage = "IN_MEMORY";
+
+    private final MinioProperties minio = new MinioProperties();
+
+    public String getStorage() {
+        return storage;
+    }
+
+    public void setStorage(String storage) {
+        this.storage = storage;
+    }
+
+    public MinioProperties getMinio() {
+        return minio;
+    }
+
+    public static class MinioProperties {
+
+        private String endpoint;
+
+        private String accessKey;
+
+        private String secretKey;
+
+        private int downloadExpirySeconds = 900;
+
+        public String getEndpoint() {
+            return endpoint;
+        }
+
+        public void setEndpoint(String endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        public String getAccessKey() {
+            return accessKey;
+        }
+
+        public void setAccessKey(String accessKey) {
+            this.accessKey = accessKey;
+        }
+
+        public String getSecretKey() {
+            return secretKey;
+        }
+
+        public void setSecretKey(String secretKey) {
+            this.secretKey = secretKey;
+        }
+
+        public int getDownloadExpirySeconds() {
+            return downloadExpirySeconds;
+        }
+
+        public void setDownloadExpirySeconds(int downloadExpirySeconds) {
+            this.downloadExpirySeconds = downloadExpirySeconds;
+        }
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/file/service/impl/InMemoryFileService.java
+++ b/backend/src/main/java/com/bob/mta/modules/file/service/impl/InMemoryFileService.java
@@ -4,7 +4,6 @@ import com.bob.mta.common.exception.BusinessException;
 import com.bob.mta.common.exception.ErrorCode;
 import com.bob.mta.modules.file.domain.FileMetadata;
 import com.bob.mta.modules.file.service.FileService;
-import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.time.OffsetDateTime;
@@ -13,7 +12,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Service
 public class InMemoryFileService implements FileService {
 
     private final Map<String, FileMetadata> storage = new ConcurrentHashMap<>();

--- a/backend/src/main/java/com/bob/mta/modules/file/service/impl/MinioFileService.java
+++ b/backend/src/main/java/com/bob/mta/modules/file/service/impl/MinioFileService.java
@@ -1,0 +1,178 @@
+package com.bob.mta.modules.file.service.impl;
+
+import com.bob.mta.common.exception.BusinessException;
+import com.bob.mta.common.exception.ErrorCode;
+import com.bob.mta.modules.file.domain.FileMetadata;
+import com.bob.mta.modules.file.service.FileService;
+import io.minio.BucketExistsArgs;
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import io.minio.RemoveObjectArgs;
+import io.minio.StatObjectArgs;
+import io.minio.errors.ErrorResponseException;
+import io.minio.http.Method;
+import java.io.UncheckedIOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+public class MinioFileService implements FileService {
+
+    private static final Logger log = LoggerFactory.getLogger(MinioFileService.class);
+
+    private final MinioClient minioClient;
+    private final int downloadExpirySeconds;
+    private final Clock clock;
+    private final Map<String, FileMetadata> storage = new ConcurrentHashMap<>();
+    private final Set<String> ensuredBuckets = ConcurrentHashMap.newKeySet();
+
+    public MinioFileService(MinioClient minioClient, Duration downloadExpiry) {
+        this(minioClient, downloadExpiry, Clock.systemUTC());
+    }
+
+    MinioFileService(MinioClient minioClient, Duration downloadExpiry, Clock clock) {
+        if (downloadExpiry == null || downloadExpiry.isNegative() || downloadExpiry.isZero()) {
+            throw new IllegalArgumentException("downloadExpiry must be positive");
+        }
+        this.minioClient = minioClient;
+        long seconds = downloadExpiry.getSeconds();
+        this.downloadExpirySeconds = (int) Math.min(seconds, Integer.MAX_VALUE);
+        this.clock = clock == null ? Clock.systemUTC() : clock;
+    }
+
+    @Override
+    public FileMetadata register(String fileName, String contentType, long size, String bucket, String bizType,
+                                 String bizId, String uploader) {
+        if (!StringUtils.hasText(bucket)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "file.bucket_required");
+        }
+        String id = UUID.randomUUID().toString();
+        String safeFileName = sanitizeFileName(fileName);
+        String objectKey = id + "/" + safeFileName;
+        ensureBucket(bucket);
+        FileMetadata metadata = new FileMetadata(id,
+                fileName,
+                contentType,
+                size,
+                bucket,
+                objectKey,
+                bizType,
+                bizId,
+                OffsetDateTime.now(clock),
+                uploader);
+        storage.put(id, metadata);
+        log.debug("Registered file {} in bucket {} with key {}", id, bucket, objectKey);
+        return metadata;
+    }
+
+    @Override
+    public FileMetadata get(String id) {
+        FileMetadata metadata = storage.get(id);
+        if (metadata == null) {
+            throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+        }
+        return metadata;
+    }
+
+    @Override
+    public List<FileMetadata> listByBiz(String bizType, String bizId) {
+        return storage.values().stream()
+                .filter(meta -> !StringUtils.hasText(bizType) || bizType.equals(meta.getBizType()))
+                .filter(meta -> !StringUtils.hasText(bizId) || bizId.equals(meta.getBizId()))
+                .sorted((left, right) -> right.getUploadedAt().compareTo(left.getUploadedAt()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void delete(String id) {
+        FileMetadata metadata = storage.get(id);
+        if (metadata == null) {
+            throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+        }
+        try {
+            minioClient.removeObject(RemoveObjectArgs.builder()
+                    .bucket(metadata.getBucket())
+                    .object(metadata.getObjectKey())
+                    .build());
+        } catch (ErrorResponseException e) {
+            if (!"NoSuchKey".equals(e.errorResponse().code())) {
+                log.error("Failed to delete object {}/{}", metadata.getBucket(), metadata.getObjectKey(), e);
+                throw new BusinessException(ErrorCode.INTERNAL_ERROR, "file.delete_failed");
+            }
+        } catch (Exception e) {
+            log.error("Failed to delete object {}/{}", metadata.getBucket(), metadata.getObjectKey(), e);
+            throw new BusinessException(ErrorCode.INTERNAL_ERROR, "file.delete_failed");
+        }
+        storage.remove(id);
+    }
+
+    @Override
+    public String buildDownloadUrl(FileMetadata metadata) {
+        if (metadata == null) {
+            throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+        }
+        try {
+            // Ensure object exists before creating presigned url to provide early feedback.
+            minioClient.statObject(StatObjectArgs.builder()
+                    .bucket(metadata.getBucket())
+                    .object(metadata.getObjectKey())
+                    .build());
+            return minioClient.getPresignedObjectUrl(GetPresignedObjectUrlArgs.builder()
+                    .bucket(metadata.getBucket())
+                    .object(metadata.getObjectKey())
+                    .method(Method.GET)
+                    .expiry(downloadExpirySeconds)
+                    .build());
+        } catch (ErrorResponseException e) {
+            if ("NoSuchKey".equals(e.errorResponse().code())) {
+                throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+            }
+            log.error("Failed to build download URL for {}/{}", metadata.getBucket(), metadata.getObjectKey(), e);
+            throw new BusinessException(ErrorCode.INTERNAL_ERROR, "file.download_failed");
+        } catch (UncheckedIOException e) {
+            log.error("I/O error when building download URL for {}/{}", metadata.getBucket(), metadata.getObjectKey(), e);
+            throw new BusinessException(ErrorCode.INTERNAL_ERROR, "file.download_failed");
+        } catch (Exception e) {
+            log.error("Unexpected error when building download URL for {}/{}", metadata.getBucket(), metadata.getObjectKey(), e);
+            throw new BusinessException(ErrorCode.INTERNAL_ERROR, "file.download_failed");
+        }
+    }
+
+    private void ensureBucket(String bucket) {
+        if (ensuredBuckets.contains(bucket)) {
+            return;
+        }
+        if (!ensuredBuckets.add(bucket)) {
+            return;
+        }
+        try {
+            boolean exists = minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
+            if (!exists) {
+                minioClient.makeBucket(MakeBucketArgs.builder().bucket(bucket).build());
+            }
+        } catch (Exception e) {
+            ensuredBuckets.remove(bucket);
+            log.error("Failed to ensure bucket {} exists", bucket, e);
+            throw new BusinessException(ErrorCode.INTERNAL_ERROR, "file.bucket_unavailable");
+        }
+    }
+
+    private String sanitizeFileName(String fileName) {
+        if (!StringUtils.hasText(fileName)) {
+            return "file";
+        }
+        String normalized = fileName.trim();
+        String sanitized = normalized.replaceAll("[^A-Za-z0-9._-]", "_");
+        return sanitized.isEmpty() ? "file" : sanitized;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -42,3 +42,11 @@ logging:
     com.bob.mta: DEBUG
   pattern:
     console: '{"timestamp":"%d{yyyy-MM-dd''T''HH:mm:ss.SSSZ}","level":"%p","logger":"%c{1}","thread":"%t","message":%msg,"trace":%ex}'
+app:
+  file:
+    storage: IN_MEMORY
+    minio:
+      endpoint: http://localhost:9000
+      access-key: minioadmin
+      secret-key: minioadmin
+      download-expiry-seconds: 900

--- a/backend/src/test/java/com/bob/mta/modules/file/MinioFileIntegrationTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/file/MinioFileIntegrationTest.java
@@ -1,0 +1,278 @@
+package com.bob.mta.modules.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import io.minio.StatObjectArgs;
+import io.minio.errors.ErrorResponseException;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MinioFileIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(MinioFileIntegrationTest.class);
+    private static final String MINIO_IMAGE = "quay.io/minio/minio:RELEASE.2024-03-30T09-41-56Z";
+    private static final String MINIO_USER = "minio";
+    private static final String MINIO_PASSWORD = "minio123456";
+
+    @Container
+    static final GenericContainer<?> MINIO = new GenericContainer<>(DockerImageName.parse(MINIO_IMAGE))
+            .withEnv("MINIO_ROOT_USER", MINIO_USER)
+            .withEnv("MINIO_ROOT_PASSWORD", MINIO_PASSWORD)
+            .withCommand("server /data --console-address :9001")
+            .withExposedPorts(9000, 9001)
+            .waitingFor(Wait.forHttp("/minio/health/ready").forPort(9000).forStatusCode(200))
+            .withStartupTimeout(Duration.ofMinutes(2));
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("app.file.storage", () -> "MINIO");
+        registry.add("app.file.minio.endpoint", () -> "http://" + MINIO.getHost() + ":" + MINIO.getMappedPort(9000));
+        registry.add("app.file.minio.access-key", () -> MINIO_USER);
+        registry.add("app.file.minio.secret-key", () -> MINIO_PASSWORD);
+        registry.add("app.file.minio.download-expiry-seconds", () -> 300);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MinioClient minioClient;
+
+    @Test
+    @DisplayName("plan attachments leverage MinIO storage end-to-end")
+    void shouldHandleAttachmentLifecycleWithMinio() throws Exception {
+        String token = authenticate();
+
+        byte[] attachmentContent = "Checklist evidence".getBytes(StandardCharsets.UTF_8);
+        JsonNode attachmentMetadata = registerFile(token, "plan-attachments", "PLAN_NODE", "node-alpha",
+                "evidence.txt", "text/plain", attachmentContent.length);
+        String attachmentFileId = attachmentMetadata.path("data").path("id").asText();
+        String attachmentBucket = attachmentMetadata.path("data").path("bucket").asText();
+        String attachmentObjectKey = attachmentMetadata.path("data").path("objectKey").asText();
+        assertThat(attachmentFileId).isNotBlank();
+        uploadObject(attachmentBucket, attachmentObjectKey, attachmentContent, "text/plain");
+
+        byte[] staleContent = "to be removed".getBytes(StandardCharsets.UTF_8);
+        JsonNode staleMetadata = registerFile(token, "temp-files", "TEMP", "cleanup",
+                "old.txt", "text/plain", staleContent.length);
+        String staleFileId = staleMetadata.path("data").path("id").asText();
+        String staleBucket = staleMetadata.path("data").path("bucket").asText();
+        String staleObjectKey = staleMetadata.path("data").path("objectKey").asText();
+        uploadObject(staleBucket, staleObjectKey, staleContent, "text/plain");
+
+        mockMvc.perform(delete("/api/v1/files/" + staleFileId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/files/" + staleFileId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+        assertThatThrownBy(() -> minioClient.statObject(StatObjectArgs.builder()
+                        .bucket(staleBucket)
+                        .object(staleObjectKey)
+                        .build()))
+                .isInstanceOf(ErrorResponseException.class);
+
+        JsonNode plan = createPlan(token);
+        String planId = plan.path("data").path("id").asText();
+        assertThat(planId).isNotBlank();
+
+        mockMvc.perform(post("/api/v1/plans/" + planId + "/publish")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/plans/" + planId + "/nodes/node-alpha/start")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of("operatorId", "admin"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/plans/" + planId + "/nodes/node-alpha/complete")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "operatorId", "admin",
+                                "resultSummary", "Completed",
+                                "log", "All checks passed",
+                                "fileIds", List.of(attachmentFileId)))))
+                .andExpect(status().isOk());
+
+        MvcResult detailResult = mockMvc.perform(get("/api/v1/plans/" + planId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode detail = objectMapper.readTree(detailResult.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        JsonNode attachments = detail.path("data").path("nodes").get(0).path("execution").path("attachments");
+        assertThat(attachments).isNotNull();
+        assertThat(attachments.isArray()).isTrue();
+        assertThat(attachments).hasSize(1);
+        JsonNode attachment = attachments.get(0);
+        assertThat(attachment.path("id").asText()).isEqualTo(attachmentFileId);
+        assertThat(attachment.path("name").asText()).isEqualTo("evidence.txt");
+        String downloadUrl = attachment.path("downloadUrl").asText();
+        assertThat(downloadUrl).isNotBlank();
+
+        HttpClient httpClient = HttpClient.newHttpClient();
+        HttpRequest downloadRequest = HttpRequest.newBuilder(URI.create(downloadUrl)).GET().build();
+        HttpResponse<byte[]> downloadResponse = httpClient.send(downloadRequest, HttpResponse.BodyHandlers.ofByteArray());
+        assertThat(downloadResponse.statusCode()).isEqualTo(200);
+        assertThat(new String(downloadResponse.body(), StandardCharsets.UTF_8)).isEqualTo("Checklist evidence");
+
+        MvcResult timelineResult = mockMvc.perform(get("/api/v1/plans/" + planId + "/timeline")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode timeline = objectMapper.readTree(timelineResult.getResponse().getContentAsString(StandardCharsets.UTF_8))
+                .path("data");
+        assertThat(timeline.isArray()).isTrue();
+        boolean nodeCompleted = false;
+        for (JsonNode event : timeline) {
+            if ("NODE_COMPLETED".equals(event.path("type").asText())) {
+                nodeCompleted = true;
+                break;
+            }
+        }
+        assertThat(nodeCompleted).isTrue();
+
+        MvcResult listResult = mockMvc.perform(get("/api/v1/files")
+                        .header("Authorization", "Bearer " + token)
+                        .param("bizType", "PLAN_NODE")
+                        .param("bizId", "node-alpha"))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode listBody = objectMapper.readTree(listResult.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        JsonNode listData = listBody.path("data");
+        assertThat(listData.isArray()).isTrue();
+        boolean foundAttachment = false;
+        for (JsonNode node : listData) {
+            if (attachmentFileId.equals(node.path("id").asText())) {
+                assertThat(node.path("downloadUrl").asText()).isNotBlank();
+                foundAttachment = true;
+            }
+        }
+        assertThat(foundAttachment).isTrue();
+    }
+
+    private JsonNode registerFile(String token, String bucket, String bizType, String bizId,
+                                  String fileName, String contentType, long size) throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("fileName", fileName);
+        payload.put("contentType", contentType);
+        payload.put("size", size);
+        payload.put("bucket", bucket);
+        payload.put("bizType", bizType);
+        payload.put("bizId", bizId);
+        MvcResult result = mockMvc.perform(post("/api/v1/files")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(payload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").isNotEmpty())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8));
+    }
+
+    private void uploadObject(String bucket, String objectKey, byte[] content, String contentType) {
+        try {
+            minioClient.putObject(PutObjectArgs.builder()
+                    .bucket(bucket)
+                    .object(objectKey)
+                    .stream(new ByteArrayInputStream(content), content.length, -1)
+                    .contentType(contentType)
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to upload object {} in bucket {}", objectKey, bucket, e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private JsonNode createPlan(String token) throws Exception {
+        Map<String, Object> node = new HashMap<>();
+        node.put("id", "node-alpha");
+        node.put("name", "Initial checks");
+        node.put("type", "CHECKLIST");
+        node.put("assignee", "operator");
+        node.put("order", 1);
+        node.put("expectedDurationMinutes", 30);
+        node.put("actionType", "NONE");
+        node.put("completionThreshold", 100);
+        node.put("children", List.of());
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("tenantId", "tenant-files");
+        payload.put("title", "Plan with attachments");
+        payload.put("description", "Verify file storage integration");
+        payload.put("customerId", "cust-files");
+        payload.put("owner", "admin");
+        payload.put("startTime", OffsetDateTime.now().plusDays(1));
+        payload.put("endTime", OffsetDateTime.now().plusDays(1).plusHours(2));
+        payload.put("timezone", "Asia/Tokyo");
+        payload.put("participants", List.of("admin", "operator"));
+        payload.put("nodes", List.of(node));
+
+        MvcResult result = mockMvc.perform(post("/api/v1/plans")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(payload)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8));
+    }
+
+    private String authenticate() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "username", "admin",
+                                "password", "admin123"))))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString(StandardCharsets.UTF_8));
+        String token = body.path("data").path("token").asText();
+        assertThat(token).isNotBlank();
+        return token;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce configuration-driven file storage that selects between in-memory and MinIO implementations via application properties
- add a MinIO-based FileService with presigned download support and update error handling/configuration defaults
- provide integration coverage that exercises plan attachments and timeline flows against a MinIO Testcontainers instance

## Testing
- mvn -q -DskipTests package *(fails: unable to download Spring Boot parent due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68db9eac02dc832faffcb97f72b525ab