### PR TITLE
Configure plan persistence infrastructure

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanPersistenceConfiguration.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanPersistenceConfiguration.java
@@ -17,12 +17,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import javax.sql.DataSource;
 
 @Configuration
 @ConditionalOnClass(org.apache.ibatis.session.SqlSessionFactory.class)
 @EnableConfigurationProperties(DataSourceProperties.class)
+@EnableTransactionManagement
 @MapperScan(basePackageClasses = {
         PlanAggregateMapper.class,
         com.bob.mta.common.i18n.persistence.MultilingualTextMapper.class,

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,6 +24,9 @@ spring:
       mode: never
 mybatis:
   mapper-locations: classpath:/mapper/*.xml
+  type-handlers-package: com.bob.mta.common.mybatis
+  configuration:
+    map-underscore-to-camel-case: true
 server:
   port: 8080
 management:

--- a/backend/src/main/resources/mapper/PlanAggregateMapper.xml
+++ b/backend/src/main/resources/mapper/PlanAggregateMapper.xml
@@ -484,6 +484,7 @@
         <foreach collection="planIds" item="planId" open="(" separator="," close=")">
             #{planId}
         </foreach>
+        ORDER BY plan_id, participant_id
     </select>
 
     <select id="findNodesByPlanIds" parameterType="list" resultMap="PlanNodeResult">
@@ -504,6 +505,7 @@
         <foreach collection="planIds" item="planId" open="(" separator="," close=")">
             #{planId}
         </foreach>
+        ORDER BY plan_id, order_index, node_id
     </select>
 
     <select id="findExecutionsByPlanIds" parameterType="list" resultMap="PlanExecutionResult">
@@ -520,6 +522,7 @@
         <foreach collection="planIds" item="planId" open="(" separator="," close=")">
             #{planId}
         </foreach>
+        ORDER BY plan_id, node_id
     </select>
 
     <select id="findAttachmentsByPlanIds" parameterType="list" resultMap="PlanAttachmentResult">
@@ -529,6 +532,7 @@
         <foreach collection="planIds" item="planId" open="(" separator="," close=")">
             #{planId}
         </foreach>
+        ORDER BY plan_id, node_id, file_id
     </select>
 
     <select id="findActivitiesByPlanIds" parameterType="list" resultMap="PlanActivityResult">
@@ -545,6 +549,7 @@
         <foreach collection="planIds" item="planId" open="(" separator="," close=")">
             #{planId}
         </foreach>
+        ORDER BY plan_id, occurred_at, activity_id
     </select>
 
     <select id="findReminderRulesByPlanIds" parameterType="list" resultMap="PlanReminderRuleResult">
@@ -562,6 +567,7 @@
         <foreach collection="planIds" item="planId" open="(" separator="," close=")">
             #{planId}
         </foreach>
+        ORDER BY plan_id, rule_id
     </select>
 
     <insert id="insertPlan" parameterType="com.bob.mta.modules.plan.persistence.PlanEntity">

--- a/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistenceAnalyticsRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistenceAnalyticsRepositoryIntegrationTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
 class PlanPersistenceAnalyticsRepositoryIntegrationTest {
 
     @Container

--- a/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepositoryTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepositoryTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
 class PlanPersistencePlanRepositoryTest {
 
     @Container

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/bobmta_test
+    username: bobmta
+    password: secret
+    driver-class-name: org.postgresql.Driver
+  sql:
+    init:
+      mode: never
+mybatis:
+  mapper-locations: classpath:/mapper/*.xml
+  type-handlers-package: com.bob.mta.common.mybatis
+  configuration:
+    map-underscore-to-camel-case: true
+logging:
+  level:
+    root: WARN


### PR DESCRIPTION
## Summary
- enable Spring transaction management and enrich MyBatis configuration for the plan persistence module
- ensure plan-related MyBatis mappers order association queries for stable reconstruction
- provide PostgreSQL-oriented application-test profile and activate it in Testcontainers-based integration tests

## Testing
- mvn test *(fails: unable to download Spring Boot parent because Maven Central returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc824f1774832fad3ca303f262bcb1