### PR TITLE
Add Flyway migrations and SQL integration tests for plan module

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -62,6 +62,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>${jjwt.version}</version>

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,6 +22,10 @@ spring:
     init:
       platform: postgresql
       mode: never
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
 mybatis:
   mapper-locations: classpath:/mapper/*.xml
 server:

--- a/backend/src/main/resources/db/data.sql
+++ b/backend/src/main/resources/db/data.sql
@@ -1,0 +1,63 @@
+-- -----------------------------------------------------------------------------
+-- BOB MTA Maintenance Assistants - 示例数据
+-- 用于本地开发或测试环境快速演示计划聚合数据结构。
+-- 如需恢复空库，请先执行 schema.sql，再按需导入本文件。
+-- -----------------------------------------------------------------------------
+
+INSERT INTO mt_plan (plan_id, tenant_id, customer_id, owner_id, title, description, status,
+                     planned_start_time, planned_end_time, timezone, created_at, updated_at)
+VALUES
+    ('PLAN-00000001', 'tenant-demo', 'customer-a', 'owner-alpha', '预防性巡检-东京数据中心',
+     '检查冷却系统与配电柜，确认巡检清单。', 'SCHEDULED',
+     NOW() + INTERVAL '1 day', NOW() + INTERVAL '2 days', 'Asia/Tokyo', NOW(), NOW()),
+    ('PLAN-00000002', 'tenant-demo', 'customer-b', 'owner-beta', '应急演练-灾备切换',
+     '模拟核心服务故障并在 30 分钟内完成灾备切换演练。', 'IN_PROGRESS',
+     NOW() - INTERVAL '1 hour', NOW() + INTERVAL '5 hours', 'Asia/Shanghai', NOW(), NOW()),
+    ('PLAN-00000003', 'tenant-demo', 'customer-a', 'owner-gamma', '巡检总结与复盘',
+     '收集巡检日志并输出问题清单，准备向客户汇报。', 'COMPLETED',
+     NOW() - INTERVAL '3 days', NOW() - INTERVAL '2 days', 'Asia/Shanghai', NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO mt_plan_participant (plan_id, participant_id) VALUES
+    ('PLAN-00000001', 'user-ops-001'),
+    ('PLAN-00000001', 'user-ops-002'),
+    ('PLAN-00000002', 'user-ops-003'),
+    ('PLAN-00000002', 'user-ops-004'),
+    ('PLAN-00000003', 'user-ops-001')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO mt_plan_node (plan_id, node_id, parent_node_id, name, type, assignee, order_index,
+                           expected_duration_minutes, action_type, completion_threshold, action_ref, description)
+VALUES
+    ('PLAN-00000001', 'NODE-00000001', NULL, '冷却系统巡检', 'TASK', 'user-ops-001', 0, 60, 'MANUAL', 100, 'checklist-cooling', '按照表单巡检温控。'),
+    ('PLAN-00000001', 'NODE-00000002', 'NODE-00000001', '配电柜巡检', 'TASK', 'user-ops-002', 1, 45, 'MANUAL', 100, 'checklist-power', '确认备用电源及警报。'),
+    ('PLAN-00000002', 'NODE-00000003', NULL, '演练启动', 'TASK', 'user-ops-003', 0, 30, 'MANUAL', 100, 'drill-start', '宣布演练目标与角色分配。'),
+    ('PLAN-00000002', 'NODE-00000004', 'NODE-00000003', '灾备切换', 'TASK', 'user-ops-004', 1, 45, 'API_CALL', 80, 'drill-switch', '执行灾备切换流程。'),
+    ('PLAN-00000003', 'NODE-00000005', NULL, '巡检材料收集', 'TASK', 'user-ops-001', 0, 40, 'MANUAL', 100, 'review-collect', '整理巡检记录与附件。')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO mt_plan_node_execution (plan_id, node_id, status, start_time, end_time, operator_id, result_summary, execution_log)
+VALUES
+    ('PLAN-00000002', 'NODE-00000003', 'DONE', NOW() - INTERVAL '2 hours', NOW() - INTERVAL '90 minutes', 'user-ops-003', '演练已启动', 'log-start'),
+    ('PLAN-00000002', 'NODE-00000004', 'IN_PROGRESS', NOW() - INTERVAL '60 minutes', NULL, 'user-ops-004', '灾备切换进行中', 'log-switch'),
+    ('PLAN-00000003', 'NODE-00000005', 'DONE', NOW() - INTERVAL '3 days', NOW() - INTERVAL '70 hours', 'user-ops-001', '巡检总结完成', 'log-review')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO mt_plan_node_attachment (plan_id, node_id, file_id) VALUES
+    ('PLAN-00000001', 'NODE-00000001', 'file-cooling-report'),
+    ('PLAN-00000001', 'NODE-00000002', 'file-power-report'),
+    ('PLAN-00000002', 'NODE-00000003', 'file-drill-briefing')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO mt_plan_activity (plan_id, activity_id, activity_type, occurred_at, actor_id, message_key, reference_id, attributes)
+VALUES
+    ('PLAN-00000002', 'ACT-00000001', 'PLAN_STARTED', NOW() - INTERVAL '2 hours', 'user-ops-003', 'plan.activity.planStarted', 'NODE-00000003', '{"shift":"A"}'),
+    ('PLAN-00000002', 'ACT-00000002', 'NODE_COMPLETED', NOW() - INTERVAL '90 minutes', 'user-ops-003', 'plan.activity.nodeCompleted', 'NODE-00000003', '{"result":"ok"}'),
+    ('PLAN-00000003', 'ACT-00000003', 'PLAN_COMPLETED', NOW() - INTERVAL '2 days', 'user-ops-001', 'plan.activity.planCompleted', NULL, '{"report":"delivered"}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO mt_plan_reminder_rule (plan_id, rule_id, trigger, offset_minutes, channels, template_id, recipients, description, active)
+VALUES
+    ('PLAN-00000001', 'REM-00000001', 'BEFORE_START', 60, '["EMAIL"]', 'tmpl-plan-reminder', '["owner-alpha","user-ops-001"]', '开工前一小时提醒执行人', TRUE),
+    ('PLAN-00000002', 'REM-00000002', 'AFTER_NODE', 15, '["EMAIL","IM"]', 'tmpl-node-reminder', '["owner-beta"]', '节点完成后通知负责人', TRUE)
+ON CONFLICT DO NOTHING;

--- a/backend/src/main/resources/db/migration/V1__plan_module.sql
+++ b/backend/src/main/resources/db/migration/V1__plan_module.sql
@@ -1,0 +1,120 @@
+-- -----------------------------------------------------------------------------
+-- Flyway V1 - Plan module schema baseline
+-- -----------------------------------------------------------------------------
+
+CREATE SEQUENCE mt_plan_id_seq AS BIGINT START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE mt_plan_node_id_seq AS BIGINT START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE mt_plan_reminder_id_seq AS BIGINT START WITH 1 INCREMENT BY 1;
+
+CREATE TABLE mt_plan (
+    plan_id              VARCHAR(64) PRIMARY KEY,
+    tenant_id            VARCHAR(64)    NOT NULL,
+    customer_id          VARCHAR(64),
+    owner_id             VARCHAR(64),
+    title                VARCHAR(255)   NOT NULL,
+    description          TEXT,
+    status               VARCHAR(32)    NOT NULL,
+    planned_start_time   TIMESTAMPTZ,
+    planned_end_time     TIMESTAMPTZ,
+    actual_start_time    TIMESTAMPTZ,
+    actual_end_time      TIMESTAMPTZ,
+    cancel_reason        TEXT,
+    canceled_by          VARCHAR(64),
+    canceled_at          TIMESTAMPTZ,
+    timezone             VARCHAR(64)    NOT NULL,
+    created_at           TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    reminder_updated_at  TIMESTAMPTZ,
+    reminder_updated_by  VARCHAR(64)
+);
+
+CREATE INDEX idx_mt_plan_tenant_status ON mt_plan (tenant_id, status);
+CREATE INDEX idx_mt_plan_tenant_start ON mt_plan (tenant_id, planned_start_time);
+CREATE INDEX idx_mt_plan_tenant_end ON mt_plan (tenant_id, planned_end_time);
+CREATE INDEX idx_mt_plan_customer_status ON mt_plan (customer_id, status);
+CREATE INDEX idx_mt_plan_owner_status ON mt_plan (owner_id, status);
+
+CREATE TABLE mt_plan_participant (
+    plan_id        VARCHAR(64) NOT NULL,
+    participant_id VARCHAR(64) NOT NULL,
+    PRIMARY KEY (plan_id, participant_id),
+    CONSTRAINT fk_plan_participant_plan FOREIGN KEY (plan_id) REFERENCES mt_plan(plan_id) ON DELETE CASCADE
+);
+
+CREATE TABLE mt_plan_node (
+    plan_id                   VARCHAR(64) NOT NULL,
+    node_id                   VARCHAR(64) NOT NULL,
+    parent_node_id            VARCHAR(64),
+    name                      VARCHAR(255) NOT NULL,
+    type                      VARCHAR(64)  NOT NULL,
+    assignee                  VARCHAR(64),
+    order_index               INT          NOT NULL,
+    expected_duration_minutes INT,
+    action_type               VARCHAR(64),
+    completion_threshold      INT,
+    action_ref                VARCHAR(255),
+    description               TEXT,
+    PRIMARY KEY (plan_id, node_id),
+    CONSTRAINT fk_plan_node_plan FOREIGN KEY (plan_id) REFERENCES mt_plan(plan_id) ON DELETE CASCADE,
+    CONSTRAINT fk_plan_node_parent FOREIGN KEY (plan_id, parent_node_id)
+        REFERENCES mt_plan_node(plan_id, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_mt_plan_node_parent ON mt_plan_node (plan_id, parent_node_id);
+CREATE INDEX idx_mt_plan_node_order ON mt_plan_node (plan_id, order_index);
+
+CREATE TABLE mt_plan_node_execution (
+    plan_id        VARCHAR(64) NOT NULL,
+    node_id        VARCHAR(64) NOT NULL,
+    status         VARCHAR(32) NOT NULL,
+    start_time     TIMESTAMPTZ,
+    end_time       TIMESTAMPTZ,
+    operator_id    VARCHAR(64),
+    result_summary TEXT,
+    execution_log  TEXT,
+    PRIMARY KEY (plan_id, node_id),
+    CONSTRAINT fk_plan_execution_node FOREIGN KEY (plan_id, node_id)
+        REFERENCES mt_plan_node(plan_id, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_mt_plan_node_execution_status ON mt_plan_node_execution (status);
+
+CREATE TABLE mt_plan_node_attachment (
+    plan_id VARCHAR(64) NOT NULL,
+    node_id VARCHAR(64) NOT NULL,
+    file_id VARCHAR(128) NOT NULL,
+    PRIMARY KEY (plan_id, node_id, file_id),
+    CONSTRAINT fk_plan_attachment_node FOREIGN KEY (plan_id, node_id)
+        REFERENCES mt_plan_node(plan_id, node_id) ON DELETE CASCADE
+);
+
+CREATE TABLE mt_plan_activity (
+    plan_id       VARCHAR(64) NOT NULL,
+    activity_id   VARCHAR(64) NOT NULL,
+    activity_type VARCHAR(64) NOT NULL,
+    occurred_at   TIMESTAMPTZ NOT NULL,
+    actor_id      VARCHAR(64),
+    message_key   VARCHAR(255),
+    reference_id  VARCHAR(64),
+    attributes    JSONB        NOT NULL DEFAULT '{}'::JSONB,
+    PRIMARY KEY (plan_id, activity_id),
+    CONSTRAINT fk_plan_activity_plan FOREIGN KEY (plan_id) REFERENCES mt_plan(plan_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_mt_plan_activity_occurred ON mt_plan_activity (plan_id, occurred_at DESC);
+
+CREATE TABLE mt_plan_reminder_rule (
+    plan_id       VARCHAR(64) NOT NULL,
+    rule_id       VARCHAR(64) NOT NULL,
+    trigger       VARCHAR(64) NOT NULL,
+    offset_minutes INT        NOT NULL,
+    channels      JSONB       NOT NULL DEFAULT '[]'::JSONB,
+    template_id   VARCHAR(64),
+    recipients    JSONB       NOT NULL DEFAULT '[]'::JSONB,
+    description   TEXT,
+    active        BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (plan_id, rule_id),
+    CONSTRAINT fk_plan_reminder_plan FOREIGN KEY (plan_id) REFERENCES mt_plan(plan_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_mt_plan_reminder_active ON mt_plan_reminder_rule (plan_id, active);

--- a/backend/src/main/resources/db/schema.sql
+++ b/backend/src/main/resources/db/schema.sql
@@ -1,0 +1,134 @@
+-- -----------------------------------------------------------------------------
+-- BOB MTA Maintenance Assistants - PostgreSQL schema baseline
+-- -----------------------------------------------------------------------------
+-- 迁移策略说明：
+-- 1. 所有结构变更必须以 Flyway 版本脚本（classpath:db/migration/V__*.sql）交付。
+--    当前仓库以 V1__plan_module.sql 建立计划、节点、提醒等基础表。
+-- 2. 后续如需新增字段或索引，请创建新的 V{n}__description.sql 文件，避免修改已发布版本。
+-- 3. 若需手动初始化或在测试环境快速重置，可直接执行本文件中的 DDL，并视需要再运行 data.sql。
+-- -----------------------------------------------------------------------------
+
+-- 序列定义 --------------------------------------------------------------------
+CREATE SEQUENCE IF NOT EXISTS mt_plan_id_seq AS BIGINT START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS mt_plan_node_id_seq AS BIGINT START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS mt_plan_reminder_id_seq AS BIGINT START WITH 1 INCREMENT BY 1;
+
+-- 主表：运维计划 --------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mt_plan (
+    plan_id              VARCHAR(64) PRIMARY KEY,
+    tenant_id            VARCHAR(64)    NOT NULL,
+    customer_id          VARCHAR(64),
+    owner_id             VARCHAR(64),
+    title                VARCHAR(255)   NOT NULL,
+    description          TEXT,
+    status               VARCHAR(32)    NOT NULL,
+    planned_start_time   TIMESTAMPTZ,
+    planned_end_time     TIMESTAMPTZ,
+    actual_start_time    TIMESTAMPTZ,
+    actual_end_time      TIMESTAMPTZ,
+    cancel_reason        TEXT,
+    canceled_by          VARCHAR(64),
+    canceled_at          TIMESTAMPTZ,
+    timezone             VARCHAR(64)    NOT NULL,
+    created_at           TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    reminder_updated_at  TIMESTAMPTZ,
+    reminder_updated_by  VARCHAR(64)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mt_plan_tenant_status ON mt_plan (tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_mt_plan_tenant_start ON mt_plan (tenant_id, planned_start_time);
+CREATE INDEX IF NOT EXISTS idx_mt_plan_tenant_end ON mt_plan (tenant_id, planned_end_time);
+CREATE INDEX IF NOT EXISTS idx_mt_plan_customer_status ON mt_plan (customer_id, status);
+CREATE INDEX IF NOT EXISTS idx_mt_plan_owner_status ON mt_plan (owner_id, status);
+
+-- 参与者 ----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mt_plan_participant (
+    plan_id        VARCHAR(64) NOT NULL,
+    participant_id VARCHAR(64) NOT NULL,
+    PRIMARY KEY (plan_id, participant_id),
+    CONSTRAINT fk_plan_participant_plan FOREIGN KEY (plan_id) REFERENCES mt_plan(plan_id) ON DELETE CASCADE
+);
+
+-- 节点 ------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mt_plan_node (
+    plan_id                  VARCHAR(64) NOT NULL,
+    node_id                  VARCHAR(64) NOT NULL,
+    parent_node_id           VARCHAR(64),
+    name                     VARCHAR(255) NOT NULL,
+    type                     VARCHAR(64)  NOT NULL,
+    assignee                 VARCHAR(64),
+    order_index              INT          NOT NULL,
+    expected_duration_minutes INT,
+    action_type              VARCHAR(64),
+    completion_threshold     INT,
+    action_ref               VARCHAR(255),
+    description              TEXT,
+    PRIMARY KEY (plan_id, node_id),
+    CONSTRAINT fk_plan_node_plan FOREIGN KEY (plan_id) REFERENCES mt_plan(plan_id) ON DELETE CASCADE,
+    CONSTRAINT fk_plan_node_parent FOREIGN KEY (plan_id, parent_node_id)
+        REFERENCES mt_plan_node(plan_id, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mt_plan_node_parent ON mt_plan_node (plan_id, parent_node_id);
+CREATE INDEX IF NOT EXISTS idx_mt_plan_node_order ON mt_plan_node (plan_id, order_index);
+
+-- 节点执行记录 ----------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mt_plan_node_execution (
+    plan_id        VARCHAR(64) NOT NULL,
+    node_id        VARCHAR(64) NOT NULL,
+    status         VARCHAR(32) NOT NULL,
+    start_time     TIMESTAMPTZ,
+    end_time       TIMESTAMPTZ,
+    operator_id    VARCHAR(64),
+    result_summary TEXT,
+    execution_log  TEXT,
+    PRIMARY KEY (plan_id, node_id),
+    CONSTRAINT fk_plan_execution_node FOREIGN KEY (plan_id, node_id)
+        REFERENCES mt_plan_node(plan_id, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mt_plan_node_execution_status ON mt_plan_node_execution (status);
+
+-- 节点附件 --------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mt_plan_node_attachment (
+    plan_id VARCHAR(64) NOT NULL,
+    node_id VARCHAR(64) NOT NULL,
+    file_id VARCHAR(128) NOT NULL,
+    PRIMARY KEY (plan_id, node_id, file_id),
+    CONSTRAINT fk_plan_attachment_node FOREIGN KEY (plan_id, node_id)
+        REFERENCES mt_plan_node(plan_id, node_id) ON DELETE CASCADE
+);
+
+-- 计划活动 --------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mt_plan_activity (
+    plan_id       VARCHAR(64) NOT NULL,
+    activity_id   VARCHAR(64) NOT NULL,
+    activity_type VARCHAR(64) NOT NULL,
+    occurred_at   TIMESTAMPTZ NOT NULL,
+    actor_id      VARCHAR(64),
+    message_key   VARCHAR(255),
+    reference_id  VARCHAR(64),
+    attributes    JSONB        NOT NULL DEFAULT '{}'::JSONB,
+    PRIMARY KEY (plan_id, activity_id),
+    CONSTRAINT fk_plan_activity_plan FOREIGN KEY (plan_id) REFERENCES mt_plan(plan_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mt_plan_activity_occurred ON mt_plan_activity (plan_id, occurred_at DESC);
+
+-- 提醒策略 --------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mt_plan_reminder_rule (
+    plan_id       VARCHAR(64) NOT NULL,
+    rule_id       VARCHAR(64) NOT NULL,
+    trigger       VARCHAR(64) NOT NULL,
+    offset_minutes INT        NOT NULL,
+    channels      JSONB       NOT NULL DEFAULT '[]'::JSONB,
+    template_id   VARCHAR(64),
+    recipients    JSONB       NOT NULL DEFAULT '[]'::JSONB,
+    description   TEXT,
+    active        BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (plan_id, rule_id),
+    CONSTRAINT fk_plan_reminder_plan FOREIGN KEY (plan_id) REFERENCES mt_plan(plan_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mt_plan_reminder_active ON mt_plan_reminder_rule (plan_id, active);

--- a/backend/src/test/java/com/bob/mta/modules/plan/persistence/PlanAggregateMapperIntegrationTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/persistence/PlanAggregateMapperIntegrationTest.java
@@ -1,0 +1,211 @@
+package com.bob.mta.modules.plan.persistence;
+
+import com.bob.mta.modules.plan.domain.PlanStatus;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest
+@TestInstance(Lifecycle.PER_CLASS)
+class PlanAggregateMapperIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("bobmta")
+            .withUsername("bobmta")
+            .withPassword("secret");
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+    @Autowired
+    private PlanAggregateMapper mapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private Flyway flyway;
+
+    @BeforeAll
+    void migrateDatabase() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @BeforeEach
+    void resetDatabase() {
+        jdbcTemplate.execute("TRUNCATE TABLE mt_plan_activity, mt_plan_node_attachment, mt_plan_node_execution, mt_plan_node, mt_plan_participant, mt_plan_reminder_rule, mt_plan CASCADE");
+        jdbcTemplate.execute("ALTER SEQUENCE mt_plan_id_seq RESTART WITH 1");
+        jdbcTemplate.execute("ALTER SEQUENCE mt_plan_node_id_seq RESTART WITH 1");
+        jdbcTemplate.execute("ALTER SEQUENCE mt_plan_reminder_id_seq RESTART WITH 1");
+    }
+
+    @Test
+    void shouldFilterPlansByMultipleCriteriaAndPaginate() {
+        OffsetDateTime now = OffsetDateTime.of(2024, 5, 1, 12, 0, 0, 0, ZoneOffset.UTC);
+        insertPlan("PLAN-0001", "tenant-1", "customer-a", "owner-a", "Alpha Maintenance Window",
+                "确认维护窗口与审批进度。", PlanStatus.SCHEDULED, now.plusHours(2), now.plusHours(5), now, "Asia/Tokyo");
+        insertPlan("PLAN-0002", "tenant-1", "customer-a", "owner-b", "Beta Maintenance Review",
+                "联合检查维护脚本。", PlanStatus.IN_PROGRESS, now.plusHours(4), now.plusHours(8), now, "Asia/Tokyo");
+        insertPlan("PLAN-0003", "tenant-1", "customer-b", "owner-a", "Gamma Audit",
+                "离线审计流程。", PlanStatus.CANCELED, now.plusHours(6), now.plusHours(10), now, "Asia/Tokyo");
+        insertPlan("PLAN-0004", "tenant-2", "customer-a", "owner-a", "Delta Maintenance",
+                "其他租户计划。", PlanStatus.SCHEDULED, now.plusHours(1), now.plusHours(3), now, "Asia/Tokyo");
+
+        PlanQueryParameters firstPageFilter = new PlanQueryParameters(
+                "tenant-1",
+                "customer-a",
+                null,
+                "Maintenance",
+                null,
+                List.of(PlanStatus.SCHEDULED, PlanStatus.IN_PROGRESS),
+                now.plusHours(1),
+                now.plusHours(9),
+                1,
+                0,
+                null
+        );
+
+        List<PlanEntity> page1 = mapper.findPlans(firstPageFilter);
+        assertThat(page1).extracting(PlanEntity::id).containsExactly("PLAN-0001");
+        assertThat(mapper.countPlans(firstPageFilter)).isEqualTo(2);
+
+        PlanQueryParameters secondPageFilter = new PlanQueryParameters(
+                firstPageFilter.tenantId(),
+                firstPageFilter.customerId(),
+                null,
+                firstPageFilter.keyword(),
+                null,
+                firstPageFilter.statuses(),
+                firstPageFilter.plannedStartFrom(),
+                firstPageFilter.plannedEndTo(),
+                firstPageFilter.limit(),
+                1,
+                null
+        );
+
+        List<PlanEntity> page2 = mapper.findPlans(secondPageFilter);
+        assertThat(page2).extracting(PlanEntity::id).containsExactly("PLAN-0002");
+
+        PlanQueryParameters ownerFilter = new PlanQueryParameters(
+                firstPageFilter.tenantId(),
+                firstPageFilter.customerId(),
+                "owner-b",
+                firstPageFilter.keyword(),
+                PlanStatus.IN_PROGRESS,
+                null,
+                firstPageFilter.plannedStartFrom(),
+                firstPageFilter.plannedEndTo(),
+                null,
+                null,
+                null
+        );
+
+        List<PlanEntity> ownerScoped = mapper.findPlans(ownerFilter);
+        assertThat(ownerScoped).extracting(PlanEntity::id).containsExactly("PLAN-0002");
+    }
+
+    @Test
+    void shouldAggregateStatusAndOverdueMetrics() {
+        OffsetDateTime now = OffsetDateTime.of(2024, 6, 1, 9, 0, 0, 0, ZoneOffset.UTC);
+        insertPlan("PLAN-1001", "tenant-analytics", "customer-a", "owner-a", "巡检准备",
+                "准备巡检资料。", PlanStatus.SCHEDULED, now.minusHours(3), now.minusHours(1), now.minusHours(4), "Asia/Shanghai");
+        insertPlan("PLAN-1002", "tenant-analytics", "customer-a", "owner-b", "系统维护",
+                "维护中。", PlanStatus.IN_PROGRESS, now.minusHours(5), now.minusMinutes(30), now.minusHours(6), "Asia/Shanghai");
+        insertPlan("PLAN-1003", "tenant-analytics", "customer-a", "owner-c", "总结复盘",
+                "复盘结论。", PlanStatus.COMPLETED, now.minusDays(1), now.minusHours(12), now.minusDays(1), "Asia/Shanghai");
+        insertPlan("PLAN-1004", "tenant-analytics", "customer-b", "owner-d", "其他客户计划",
+                "不在统计范围。", PlanStatus.SCHEDULED, now, now.plusHours(2), now, "Asia/Shanghai");
+
+        PlanAnalyticsQueryParameters analyticsParameters = new PlanAnalyticsQueryParameters(
+                "tenant-analytics",
+                "customer-a",
+                null,
+                now.minusDays(2),
+                now.plusDays(1),
+                List.of(PlanStatus.SCHEDULED, PlanStatus.IN_PROGRESS, PlanStatus.COMPLETED),
+                now,
+                5,
+                5,
+                5,
+                now.plusHours(6)
+        );
+
+        Map<PlanStatus, Integer> statusTotals = mapper.countPlansByStatus(analyticsParameters).stream()
+                .collect(Collectors.toMap(PlanStatusCountEntity::status, PlanStatusCountEntity::total));
+
+        assertThat(statusTotals)
+                .containsEntry(PlanStatus.SCHEDULED, 1)
+                .containsEntry(PlanStatus.IN_PROGRESS, 1)
+                .containsEntry(PlanStatus.COMPLETED, 1)
+                .hasSize(3);
+
+        long overdue = mapper.countOverduePlans(analyticsParameters);
+        assertThat(overdue).isEqualTo(2L);
+    }
+
+    private void insertPlan(String planId,
+                            String tenantId,
+                            String customerId,
+                            String ownerId,
+                            String title,
+                            String description,
+                            PlanStatus status,
+                            OffsetDateTime plannedStart,
+                            OffsetDateTime plannedEnd,
+                            OffsetDateTime createdAt,
+                            String timezone) {
+        jdbcTemplate.update(
+                """
+                        INSERT INTO mt_plan (plan_id, tenant_id, customer_id, owner_id, title, description, status,
+                                             planned_start_time, planned_end_time, actual_start_time, actual_end_time,
+                                             cancel_reason, canceled_by, canceled_at, timezone, created_at, updated_at,
+                                             reminder_updated_at, reminder_updated_by)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, NULL, NULL)
+                        """,
+                planId,
+                tenantId,
+                customerId,
+                ownerId,
+                title,
+                description,
+                status.name(),
+                toTimestamp(plannedStart),
+                toTimestamp(plannedEnd),
+                timezone,
+                toTimestamp(createdAt),
+                toTimestamp(createdAt)
+        );
+    }
+
+    private Timestamp toTimestamp(OffsetDateTime value) {
+        return value == null ? null : Timestamp.from(value.toInstant());
+    }
+}


### PR DESCRIPTION
## Summary
- add PostgreSQL schema and seed scripts with migration strategy notes for the plan aggregates
- configure Flyway to apply the initial V1 schema on startup
- add integration coverage for PlanAggregateMapper filtering, pagination, and analytics queries

## Testing
- mvn test *(fails: parent POM download blocked in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc824ea3ac832f9182c6e140e60b55