### PR TITLE
Add granular plan persistence operations and dynamic file storage selection

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanAggregateMapper.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanAggregateMapper.java
@@ -3,6 +3,7 @@ package com.bob.mta.modules.plan.persistence;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 
@@ -56,6 +57,10 @@ public interface PlanAggregateMapper {
     void deleteReminderRules(@Param("planId") String planId);
 
     void insertReminderRules(@Param("rules") List<PlanReminderRuleEntity> rules);
+
+    void updateReminderAudit(@Param("planId") String planId,
+                             @Param("updatedAt") OffsetDateTime updatedAt,
+                             @Param("updatedBy") String updatedBy);
 
     String nextPlanId();
 

--- a/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanRepository.java
@@ -1,8 +1,11 @@
 package com.bob.mta.modules.plan.repository;
 
 import com.bob.mta.modules.plan.domain.Plan;
+import com.bob.mta.modules.plan.domain.PlanActivity;
+import com.bob.mta.modules.plan.domain.PlanReminderPolicy;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface PlanRepository {
@@ -24,4 +27,16 @@ public interface PlanRepository {
     String nextNodeId();
 
     String nextReminderId();
+
+    Optional<PlanReminderPolicy> findReminderPolicy(String planId);
+
+    void replaceReminderPolicy(String planId, PlanReminderPolicy policy);
+
+    List<PlanActivity> findTimeline(String planId);
+
+    void replaceTimeline(String planId, List<PlanActivity> activities);
+
+    Map<String, List<String>> findAttachments(String planId);
+
+    void replaceAttachments(String planId, Map<String, List<String>> attachments);
 }

--- a/backend/src/main/resources/mapper/PlanAggregateMapper.xml
+++ b/backend/src/main/resources/mapper/PlanAggregateMapper.xml
@@ -688,6 +688,14 @@
         </foreach>
     </insert>
 
+    <update id="updateReminderAudit">
+        UPDATE mt_plan
+        SET reminder_updated_at = #{updatedAt},
+            reminder_updated_by = #{updatedBy},
+            updated_at = COALESCE(#{updatedAt}, updated_at)
+        WHERE plan_id = #{planId}
+    </update>
+
     <select id="nextPlanId" resultType="string">
         SELECT CONCAT('PLAN-', LPAD(nextval('mt_plan_id_seq')::text, 8, '0'))
     </select>


### PR DESCRIPTION
## Summary
- extend the plan repository contract with reminder policy, timeline, and attachment operations and implement them for both in-memory and MyBatis-backed repositories
- add reusable mappers for reminders, timeline activities, and node attachments together with the supporting SQL statement to keep reminder metadata in sync
- simplify file service configuration to select the MinIO-backed implementation when a client is available while defaulting to the in-memory service otherwise

## Testing
- `mvn -pl backend test` *(fails: module not found in reactor)*
- `mvn -f backend/pom.xml test` *(fails: blocked from downloading parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68dc824e0934832f857a398700180445