### PR TITLE
Refactor plan persistence contracts and storage wiring

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/repository/InMemoryPlanRepository.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/repository/InMemoryPlanRepository.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 @Repository
 @ConditionalOnMissingBean(PlanAggregateMapper.class)
-public class InMemoryPlanRepository implements PlanRepository {
+public class InMemoryPlanRepository implements PlanAggregateRepository {
 
     private final ConcurrentMap<String, Plan> storage = new ConcurrentHashMap<>();
     private final AtomicLong planSequence = new AtomicLong(5000);

--- a/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanAggregateRepository.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanAggregateRepository.java
@@ -1,0 +1,13 @@
+package com.bob.mta.modules.plan.repository;
+
+/**
+ * Aggregates the different persistence concerns for a plan so the service layer can
+ * coordinate persistence of the core definition, reminder policies, timeline and attachments
+ * independently.
+ */
+public interface PlanAggregateRepository extends PlanRepository,
+        PlanReminderPolicyRepository,
+        PlanTimelineRepository,
+        PlanAttachmentRepository {
+}
+

--- a/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepository.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepository.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 @Repository
 @ConditionalOnBean(PlanAggregateMapper.class)
-public class PlanPersistencePlanRepository implements PlanRepository {
+public class PlanPersistencePlanRepository implements PlanAggregateRepository {
 
     private final PlanAggregateMapper mapper;
 
@@ -80,6 +80,9 @@ public class PlanPersistencePlanRepository implements PlanRepository {
     @Override
     public void delete(String id) {
         Objects.requireNonNull(id, "id");
+        mapper.deleteAttachments(id);
+        mapper.deleteActivities(id);
+        mapper.deleteReminderRules(id);
         cleanupAssociations(id);
         mapper.deletePlan(id);
     }
@@ -168,24 +171,12 @@ public class PlanPersistencePlanRepository implements PlanRepository {
         if (!aggregate.executions().isEmpty()) {
             mapper.insertExecutions(new ArrayList<>(aggregate.executions()));
         }
-        if (!aggregate.attachments().isEmpty()) {
-            mapper.insertAttachments(new ArrayList<>(aggregate.attachments()));
-        }
-        if (!aggregate.activities().isEmpty()) {
-            mapper.insertActivities(new ArrayList<>(aggregate.activities()));
-        }
-        if (!aggregate.reminderRules().isEmpty()) {
-            mapper.insertReminderRules(new ArrayList<>(aggregate.reminderRules()));
-        }
     }
 
     private void cleanupAssociations(String planId) {
-        mapper.deleteAttachments(planId);
         mapper.deleteExecutions(planId);
         mapper.deleteNodes(planId);
         mapper.deleteParticipants(planId);
-        mapper.deleteActivities(planId);
-        mapper.deleteReminderRules(planId);
     }
 
     private List<PlanAggregate> loadAggregates(List<PlanEntity> planEntities) {

--- a/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanRepository.java
@@ -5,7 +5,7 @@ import com.bob.mta.modules.plan.domain.Plan;
 import java.util.List;
 import java.util.Optional;
 
-public interface PlanRepository extends PlanReminderPolicyRepository, PlanTimelineRepository, PlanAttachmentRepository {
+public interface PlanRepository {
 
     List<Plan> findAll();
 


### PR DESCRIPTION
## Summary
- introduce a PlanAggregateRepository that composes the plan, reminder policy, timeline, and attachment repositories and update both in-memory and persistence implementations to the new contract
- adjust InMemoryPlanService to persist reminder policies, timelines, and attachments explicitly through the dedicated sub-repositories after each save
- wire MinioFileService when the persistence stack is active while keeping the in-memory implementation for non-persistent profiles, and update repository integration tests to the new persistence flow

## Testing
- mvn -DskipITs=true -Dtest=PlanPersistencePlanRepositoryTest test *(fails: cannot download parent POM from Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1c2ca6c8832f836892be5839ef95