### PR TITLE
Add integration coverage for plan persistence analytics

### DIFF
--- a/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistenceAnalyticsRepositoryTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistenceAnalyticsRepositoryTest.java
@@ -1,79 +1,214 @@
 package com.bob.mta.modules.plan.repository;
 
+import com.bob.mta.modules.plan.domain.Plan;
 import com.bob.mta.modules.plan.domain.PlanAnalytics;
+import com.bob.mta.modules.plan.domain.PlanNode;
+import com.bob.mta.modules.plan.domain.PlanNodeActionType;
+import com.bob.mta.modules.plan.domain.PlanNodeExecution;
+import com.bob.mta.modules.plan.domain.PlanNodeStatus;
+import com.bob.mta.modules.plan.domain.PlanReminderPolicy;
 import com.bob.mta.modules.plan.domain.PlanStatus;
-import com.bob.mta.modules.plan.persistence.PlanAggregateMapper;
-import com.bob.mta.modules.plan.persistence.PlanAnalyticsQueryParameters;
-import com.bob.mta.modules.plan.persistence.PlanStatusCountEntity;
-import com.bob.mta.modules.plan.persistence.PlanUpcomingPlanEntity;
 import com.bob.mta.modules.plan.repository.PlanAnalyticsQuery;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.tuple;
 
-@ExtendWith(MockitoExtension.class)
+@Testcontainers
+@SpringBootTest
+@TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles("test")
 class PlanPersistenceAnalyticsRepositoryTest {
 
-    @Mock
-    private PlanAggregateMapper mapper;
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("bobmta")
+            .withUsername("bobmta")
+            .withPassword("secret");
 
-    private PlanPersistenceAnalyticsRepository repository;
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
+    }
+
+    @Autowired
+    private PlanPersistencePlanRepository planRepository;
+
+    @Autowired
+    private PlanPersistenceAnalyticsRepository analyticsRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private InMemoryPlanRepository inMemoryPlanRepository;
+    private InMemoryPlanAnalyticsRepository inMemoryAnalyticsRepository;
+
+    @BeforeAll
+    void initializeSchema() {
+        PlanPersistenceTestDatabase.initializeSchema(jdbcTemplate);
+    }
 
     @BeforeEach
-    void setUp() {
-        repository = new PlanPersistenceAnalyticsRepository(mapper);
+    void resetDatabase() {
+        PlanPersistenceTestDatabase.cleanDatabase(jdbcTemplate);
+        inMemoryPlanRepository = new InMemoryPlanRepository();
+        inMemoryAnalyticsRepository = new InMemoryPlanAnalyticsRepository(inMemoryPlanRepository);
     }
 
     @Test
-    void shouldSummarizeCountsAndUpcomingPlans() {
-        OffsetDateTime now = OffsetDateTime.now();
+    void shouldMatchAnalyticsWithInMemoryImplementation() {
+        OffsetDateTime reference = OffsetDateTime.of(2024, 6, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+
+        Plan design = createPlan(planRepository.nextPlanId(), "tenant-analytics", PlanStatus.DESIGN,
+                "owner-5", "customer-2", null, null,
+                reference.minusDays(30), reference.minusDays(20), List.of());
+
+        Plan scheduledFuture = createPlan(planRepository.nextPlanId(), "tenant-analytics", PlanStatus.SCHEDULED,
+                "owner-1", "customer-1", reference.plusDays(1), reference.plusDays(1).plusHours(3),
+                reference.minusDays(10), reference.minusDays(5),
+                List.of(PlanNodeStatus.DONE, PlanNodeStatus.PENDING));
+
+        Plan overdue = createPlan(planRepository.nextPlanId(), "tenant-analytics", PlanStatus.IN_PROGRESS,
+                "owner-1", "customer-3", reference.minusDays(3), reference.minusHours(3),
+                reference.minusDays(12), reference.minusDays(1),
+                List.of(PlanNodeStatus.DONE, PlanNodeStatus.DONE, PlanNodeStatus.IN_PROGRESS));
+
+        Plan dueSoon = createPlan(planRepository.nextPlanId(), "tenant-analytics", PlanStatus.SCHEDULED,
+                "owner-2", "customer-1", reference.plusHours(1), reference.plusHours(3),
+                reference.minusDays(8), reference.minusDays(2),
+                List.of(PlanNodeStatus.DONE, PlanNodeStatus.PENDING, PlanNodeStatus.PENDING));
+
+        Plan completed = createPlan(planRepository.nextPlanId(), "tenant-analytics", PlanStatus.COMPLETED,
+                "owner-3", "customer-4", reference.minusDays(6), reference.minusDays(5),
+                reference.minusDays(15), reference.minusDays(6),
+                List.of(PlanNodeStatus.DONE, PlanNodeStatus.DONE));
+
+        Plan canceled = createPlan(planRepository.nextPlanId(), "tenant-analytics", PlanStatus.CANCELED,
+                "owner-4", "customer-5", reference.minusDays(4), reference.minusDays(2),
+                reference.minusDays(18), reference.minusDays(4),
+                List.of(PlanNodeStatus.PENDING));
+
+        Plan otherTenant = createPlan(planRepository.nextPlanId(), "tenant-other", PlanStatus.SCHEDULED,
+                "owner-x", "customer-x", reference.plusDays(2), reference.plusDays(2).plusHours(2),
+                reference.minusDays(9), reference.minusDays(3),
+                List.of(PlanNodeStatus.DONE));
+
+        persist(design, scheduledFuture, overdue, dueSoon, completed, canceled, otherTenant);
+
         PlanAnalyticsQuery query = PlanAnalyticsQuery.builder()
-                .tenantId("tenant-1")
-                .customerId("cust-1")
-                .ownerId("owner-55")
-                .from(now.minusDays(1))
-                .to(now.plusDays(7))
-                .referenceTime(now)
-                .upcomingLimit(3)
+                .tenantId("tenant-analytics")
+                .referenceTime(reference)
+                .upcomingLimit(5)
+                .ownerLimit(5)
+                .riskLimit(5)
+                .dueSoonMinutes(240)
+                .statuses(List.of(PlanStatus.DESIGN, PlanStatus.SCHEDULED, PlanStatus.IN_PROGRESS,
+                        PlanStatus.COMPLETED, PlanStatus.CANCELED))
                 .build();
 
-        when(mapper.countPlansByStatus(any(PlanAnalyticsQueryParameters.class))).thenReturn(List.of(
-                new PlanStatusCountEntity(PlanStatus.DESIGN, 2),
-                new PlanStatusCountEntity(PlanStatus.SCHEDULED, 1),
-                new PlanStatusCountEntity(PlanStatus.IN_PROGRESS, 1)
-        ));
-        when(mapper.countOverduePlans(any(PlanAnalyticsQueryParameters.class))).thenReturn(1L);
-        when(mapper.findUpcomingPlans(any(PlanAnalyticsQueryParameters.class))).thenReturn(List.of(
-                new PlanUpcomingPlanEntity("plan-1", "タイトル", PlanStatus.SCHEDULED,
-                        now.plusDays(1), now.plusDays(1).plusHours(2), "owner-1", "cust-1", 1L, 4L)
-        ));
+        PlanAnalytics persistence = analyticsRepository.summarize(query);
+        PlanAnalytics inMemory = inMemoryAnalyticsRepository.summarize(query);
 
-        PlanAnalytics analytics = repository.summarize(query);
+        assertThat(persistence.getTotalPlans()).isEqualTo(inMemory.getTotalPlans());
+        assertThat(persistence.getDesignCount()).isEqualTo(inMemory.getDesignCount());
+        assertThat(persistence.getScheduledCount()).isEqualTo(inMemory.getScheduledCount());
+        assertThat(persistence.getInProgressCount()).isEqualTo(inMemory.getInProgressCount());
+        assertThat(persistence.getCompletedCount()).isEqualTo(inMemory.getCompletedCount());
+        assertThat(persistence.getCanceledCount()).isEqualTo(inMemory.getCanceledCount());
+        assertThat(persistence.getOverdueCount()).isEqualTo(inMemory.getOverdueCount());
 
-        assertThat(analytics.getTotalPlans()).isEqualTo(4);
-        assertThat(analytics.getDesignCount()).isEqualTo(2);
-        assertThat(analytics.getScheduledCount()).isEqualTo(1);
-        assertThat(analytics.getInProgressCount()).isEqualTo(1);
-        assertThat(analytics.getOverdueCount()).isEqualTo(1);
-        assertThat(analytics.getUpcomingPlans()).hasSize(1);
-        assertThat(analytics.getUpcomingPlans().get(0).getProgress()).isEqualTo(25);
-
-        ArgumentCaptor<PlanAnalyticsQueryParameters> captor = ArgumentCaptor.forClass(PlanAnalyticsQueryParameters.class);
-        verify(mapper).countPlansByStatus(captor.capture());
-        assertThat(captor.getValue().tenantId()).isEqualTo("tenant-1");
-        assertThat(captor.getValue().customerId()).isEqualTo("cust-1");
-        assertThat(captor.getValue().ownerId()).isEqualTo("owner-55");
+        assertThat(upcomingTuples(persistence.getUpcomingPlans()))
+                .isEqualTo(upcomingTuples(inMemory.getUpcomingPlans()));
+        assertThat(ownerLoadTuples(persistence.getOwnerLoads()))
+                .isEqualTo(ownerLoadTuples(inMemory.getOwnerLoads()));
+        assertThat(riskPlanTuples(persistence.getRiskPlans()))
+                .isEqualTo(riskPlanTuples(inMemory.getRiskPlans()));
     }
 
+    private void persist(Plan... plans) {
+        for (Plan plan : plans) {
+            planRepository.save(plan);
+            inMemoryPlanRepository.save(plan);
+        }
+    }
+
+    private Plan createPlan(String planId,
+                            String tenantId,
+                            PlanStatus status,
+                            String owner,
+                            String customerId,
+                            OffsetDateTime plannedStart,
+                            OffsetDateTime plannedEnd,
+                            OffsetDateTime createdAt,
+                            OffsetDateTime updatedAt,
+                            List<PlanNodeStatus> executionStatuses) {
+        List<PlanNode> nodes = new ArrayList<>();
+        List<PlanNodeExecution> executions = new ArrayList<>();
+
+        for (int index = 0; index < executionStatuses.size(); index++) {
+            String nodeId = planRepository.nextNodeId();
+            PlanNode node = new PlanNode(nodeId, "Node-" + index, "TASK", owner, index,
+                    60, PlanNodeActionType.MANUAL, 100, null, "Node description " + index, List.of());
+            nodes.add(node);
+
+            OffsetDateTime start = plannedStart != null ? plannedStart.minusHours(1).plusHours(index)
+                    : createdAt.plusHours(index);
+            OffsetDateTime end = executionStatuses.get(index) == PlanNodeStatus.DONE
+                    ? start.plusHours(1)
+                    : null;
+            PlanNodeExecution execution = new PlanNodeExecution(nodeId, executionStatuses.get(index),
+                    start, end, owner, executionStatuses.get(index).name().toLowerCase(), null, List.of());
+            executions.add(execution);
+        }
+
+        return new Plan(planId, tenantId, "Plan " + planId, "Description for " + planId,
+                customerId, owner, List.of("participant-" + planId), status,
+                plannedStart, plannedEnd, null, null, null, null, null,
+                "UTC", nodes, executions, createdAt, updatedAt, List.of(), PlanReminderPolicy.empty());
+    }
+
+    private List<Tuple> upcomingTuples(List<PlanAnalytics.UpcomingPlan> plans) {
+        return plans.stream()
+                .map(plan -> tuple(plan.getId(), plan.getTitle(), plan.getStatus(),
+                        plan.getPlannedStartTime(), plan.getPlannedEndTime(),
+                        plan.getOwner(), plan.getCustomerId(), plan.getProgress()))
+                .toList();
+    }
+
+    private List<Tuple> ownerLoadTuples(List<PlanAnalytics.OwnerLoad> loads) {
+        return loads.stream()
+                .map(load -> tuple(load.getOwnerId(), load.getTotalPlans(),
+                        load.getActivePlans(), load.getOverduePlans()))
+                .toList();
+    }
+
+    private List<Tuple> riskPlanTuples(List<PlanAnalytics.RiskPlan> plans) {
+        return plans.stream()
+                .map(plan -> tuple(plan.getId(), plan.getRiskLevel(),
+                        plan.getMinutesUntilDue(), plan.getMinutesOverdue()))
+                .toList();
+    }
 }
+

--- a/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepositoryTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepositoryTest.java
@@ -57,109 +57,6 @@ class PlanPersistencePlanRepositoryTest {
         registry.add("spring.datasource.driver-class-name", POSTGRES::getDriverClassName);
     }
 
-    private static final String[] DROP_STATEMENTS = {
-            "DROP TABLE IF EXISTS mt_plan_activity",
-            "DROP TABLE IF EXISTS mt_plan_node_attachment",
-            "DROP TABLE IF EXISTS mt_plan_node_execution",
-            "DROP TABLE IF EXISTS mt_plan_node",
-            "DROP TABLE IF EXISTS mt_plan_participant",
-            "DROP TABLE IF EXISTS mt_plan_reminder_rule",
-            "DROP TABLE IF EXISTS mt_plan",
-            "DROP SEQUENCE IF EXISTS mt_plan_id_seq",
-            "DROP SEQUENCE IF EXISTS mt_plan_node_id_seq",
-            "DROP SEQUENCE IF EXISTS mt_plan_reminder_id_seq"
-    };
-
-    private static final String[] CREATE_STATEMENTS = {
-            "CREATE SEQUENCE IF NOT EXISTS mt_plan_id_seq START WITH 1",
-            "CREATE SEQUENCE IF NOT EXISTS mt_plan_node_id_seq START WITH 1",
-            "CREATE SEQUENCE IF NOT EXISTS mt_plan_reminder_id_seq START WITH 1",
-            "CREATE TABLE IF NOT EXISTS mt_plan (" +
-                    "plan_id VARCHAR(64) PRIMARY KEY, " +
-                    "tenant_id VARCHAR(64), " +
-                    "customer_id VARCHAR(64), " +
-                    "owner_id VARCHAR(64), " +
-                    "title VARCHAR(255) NOT NULL, " +
-                    "description TEXT, " +
-                    "status VARCHAR(32) NOT NULL, " +
-                    "planned_start_time TIMESTAMPTZ, " +
-                    "planned_end_time TIMESTAMPTZ, " +
-                    "actual_start_time TIMESTAMPTZ, " +
-                    "actual_end_time TIMESTAMPTZ, " +
-                    "cancel_reason TEXT, " +
-                    "canceled_by VARCHAR(64), " +
-                    "canceled_at TIMESTAMPTZ, " +
-                    "timezone VARCHAR(64), " +
-                    "created_at TIMESTAMPTZ, " +
-                    "updated_at TIMESTAMPTZ, " +
-                    "reminder_updated_at TIMESTAMPTZ, " +
-                    "reminder_updated_by VARCHAR(64))",
-            "CREATE TABLE IF NOT EXISTS mt_plan_participant (" +
-                    "plan_id VARCHAR(64) NOT NULL, " +
-                    "participant_id VARCHAR(64) NOT NULL, " +
-                    "PRIMARY KEY (plan_id, participant_id))",
-            "CREATE TABLE IF NOT EXISTS mt_plan_node (" +
-                    "plan_id VARCHAR(64) NOT NULL, " +
-                    "node_id VARCHAR(64) NOT NULL, " +
-                    "parent_node_id VARCHAR(64), " +
-                    "name VARCHAR(255) NOT NULL, " +
-                    "type VARCHAR(64) NOT NULL, " +
-                    "assignee VARCHAR(64), " +
-                    "order_index INT NOT NULL, " +
-                    "expected_duration_minutes INT, " +
-                    "action_type VARCHAR(64), " +
-                    "completion_threshold INT, " +
-                    "action_ref VARCHAR(255), " +
-                    "description TEXT, " +
-                    "PRIMARY KEY (plan_id, node_id))",
-            "CREATE TABLE IF NOT EXISTS mt_plan_node_execution (" +
-                    "plan_id VARCHAR(64) NOT NULL, " +
-                    "node_id VARCHAR(64) NOT NULL, " +
-                    "status VARCHAR(32) NOT NULL, " +
-                    "start_time TIMESTAMPTZ, " +
-                    "end_time TIMESTAMPTZ, " +
-                    "operator_id VARCHAR(64), " +
-                    "result_summary TEXT, " +
-                    "execution_log TEXT, " +
-                    "PRIMARY KEY (plan_id, node_id))",
-            "CREATE TABLE IF NOT EXISTS mt_plan_node_attachment (" +
-                    "plan_id VARCHAR(64) NOT NULL, " +
-                    "node_id VARCHAR(64) NOT NULL, " +
-                    "file_id VARCHAR(128) NOT NULL, " +
-                    "PRIMARY KEY (plan_id, node_id, file_id))",
-            "CREATE TABLE IF NOT EXISTS mt_plan_activity (" +
-                    "plan_id VARCHAR(64) NOT NULL, " +
-                    "activity_id VARCHAR(64) NOT NULL, " +
-                    "activity_type VARCHAR(64) NOT NULL, " +
-                    "occurred_at TIMESTAMPTZ NOT NULL, " +
-                    "actor_id VARCHAR(64), " +
-                    "message_key VARCHAR(255), " +
-                    "reference_id VARCHAR(64), " +
-                    "attributes JSONB, " +
-                    "PRIMARY KEY (plan_id, activity_id))",
-            "CREATE TABLE IF NOT EXISTS mt_plan_reminder_rule (" +
-                    "plan_id VARCHAR(64) NOT NULL, " +
-                    "rule_id VARCHAR(64) NOT NULL, " +
-                    "trigger VARCHAR(64) NOT NULL, " +
-                    "offset_minutes INT NOT NULL, " +
-                    "channels JSONB, " +
-                    "template_id VARCHAR(64), " +
-                    "recipients JSONB, " +
-                    "description TEXT, " +
-                    "active BOOLEAN NOT NULL, " +
-                    "PRIMARY KEY (plan_id, rule_id))"
-    };
-
-    private static final List<String> TABLES = List.of(
-            "mt_plan_activity",
-            "mt_plan_node_attachment",
-            "mt_plan_node_execution",
-            "mt_plan_node",
-            "mt_plan_participant",
-            "mt_plan_reminder_rule",
-            "mt_plan"
-    );
-
     @Autowired
     private PlanPersistencePlanRepository repository;
 
@@ -171,18 +68,13 @@ class PlanPersistencePlanRepositoryTest {
 
     @BeforeAll
     void initializeSchema() {
-        // Ensure container is started
         assertThat(dataSource).isNotNull();
-        runStatements(DROP_STATEMENTS);
-        runStatements(CREATE_STATEMENTS);
+        PlanPersistenceTestDatabase.initializeSchema(jdbcTemplate);
     }
 
     @BeforeEach
     void cleanDatabase() {
-        TABLES.forEach(table -> jdbcTemplate.execute("DELETE FROM " + table));
-        jdbcTemplate.execute("ALTER SEQUENCE mt_plan_id_seq RESTART WITH 1");
-        jdbcTemplate.execute("ALTER SEQUENCE mt_plan_node_id_seq RESTART WITH 1");
-        jdbcTemplate.execute("ALTER SEQUENCE mt_plan_reminder_id_seq RESTART WITH 1");
+        PlanPersistenceTestDatabase.cleanDatabase(jdbcTemplate);
     }
 
     @Test
@@ -304,7 +196,9 @@ class PlanPersistencePlanRepositoryTest {
 
         repository.delete(planId);
         assertThat(repository.findById(planId)).isEmpty();
-        assertThat(TABLES.stream().map(this::countRows).collect(Collectors.toList()))
+        assertThat(PlanPersistenceTestDatabase.tableNames().stream()
+                .map(table -> PlanPersistenceTestDatabase.countRows(jdbcTemplate, table))
+                .collect(Collectors.toList()))
                 .allMatch(count -> count == 0L);
     }
 
@@ -364,13 +258,4 @@ class PlanPersistencePlanRepositoryTest {
         assertThat(reminder2).isNotEqualTo(reminder1);
     }
 
-    private void runStatements(String[] statements) {
-        for (String statement : statements) {
-            jdbcTemplate.execute(statement);
-        }
-    }
-
-    private long countRows(String table) {
-        return jdbcTemplate.queryForObject("SELECT COUNT(1) FROM " + table, Long.class);
-    }
 }

--- a/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistenceTestDatabase.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistenceTestDatabase.java
@@ -1,0 +1,147 @@
+package com.bob.mta.modules.plan.repository;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+final class PlanPersistenceTestDatabase {
+
+    private static final String[] DROP_STATEMENTS = {
+            "DROP TABLE IF EXISTS mt_plan_activity",
+            "DROP TABLE IF EXISTS mt_plan_node_attachment",
+            "DROP TABLE IF EXISTS mt_plan_node_execution",
+            "DROP TABLE IF EXISTS mt_plan_node",
+            "DROP TABLE IF EXISTS mt_plan_participant",
+            "DROP TABLE IF EXISTS mt_plan_reminder_rule",
+            "DROP TABLE IF EXISTS mt_plan",
+            "DROP SEQUENCE IF EXISTS mt_plan_id_seq",
+            "DROP SEQUENCE IF EXISTS mt_plan_node_id_seq",
+            "DROP SEQUENCE IF EXISTS mt_plan_reminder_id_seq"
+    };
+
+    private static final String[] CREATE_STATEMENTS = {
+            "CREATE SEQUENCE IF NOT EXISTS mt_plan_id_seq START WITH 1",
+            "CREATE SEQUENCE IF NOT EXISTS mt_plan_node_id_seq START WITH 1",
+            "CREATE SEQUENCE IF NOT EXISTS mt_plan_reminder_id_seq START WITH 1",
+            "CREATE TABLE IF NOT EXISTS mt_plan (" +
+                    "plan_id VARCHAR(64) PRIMARY KEY, " +
+                    "tenant_id VARCHAR(64), " +
+                    "customer_id VARCHAR(64), " +
+                    "owner_id VARCHAR(64), " +
+                    "title VARCHAR(255) NOT NULL, " +
+                    "description TEXT, " +
+                    "status VARCHAR(32) NOT NULL, " +
+                    "planned_start_time TIMESTAMPTZ, " +
+                    "planned_end_time TIMESTAMPTZ, " +
+                    "actual_start_time TIMESTAMPTZ, " +
+                    "actual_end_time TIMESTAMPTZ, " +
+                    "cancel_reason TEXT, " +
+                    "canceled_by VARCHAR(64), " +
+                    "canceled_at TIMESTAMPTZ, " +
+                    "timezone VARCHAR(64), " +
+                    "created_at TIMESTAMPTZ, " +
+                    "updated_at TIMESTAMPTZ, " +
+                    "reminder_updated_at TIMESTAMPTZ, " +
+                    "reminder_updated_by VARCHAR(64))",
+            "CREATE TABLE IF NOT EXISTS mt_plan_participant (" +
+                    "plan_id VARCHAR(64) NOT NULL, " +
+                    "participant_id VARCHAR(64) NOT NULL, " +
+                    "PRIMARY KEY (plan_id, participant_id))",
+            "CREATE TABLE IF NOT EXISTS mt_plan_node (" +
+                    "plan_id VARCHAR(64) NOT NULL, " +
+                    "node_id VARCHAR(64) NOT NULL, " +
+                    "parent_node_id VARCHAR(64), " +
+                    "name VARCHAR(255) NOT NULL, " +
+                    "type VARCHAR(64) NOT NULL, " +
+                    "assignee VARCHAR(64), " +
+                    "order_index INT NOT NULL, " +
+                    "expected_duration_minutes INT, " +
+                    "action_type VARCHAR(64), " +
+                    "completion_threshold INT, " +
+                    "action_ref VARCHAR(255), " +
+                    "description TEXT, " +
+                    "PRIMARY KEY (plan_id, node_id))",
+            "CREATE TABLE IF NOT EXISTS mt_plan_node_execution (" +
+                    "plan_id VARCHAR(64) NOT NULL, " +
+                    "node_id VARCHAR(64) NOT NULL, " +
+                    "status VARCHAR(32) NOT NULL, " +
+                    "start_time TIMESTAMPTZ, " +
+                    "end_time TIMESTAMPTZ, " +
+                    "operator_id VARCHAR(64), " +
+                    "result_summary TEXT, " +
+                    "execution_log TEXT, " +
+                    "PRIMARY KEY (plan_id, node_id))",
+            "CREATE TABLE IF NOT EXISTS mt_plan_node_attachment (" +
+                    "plan_id VARCHAR(64) NOT NULL, " +
+                    "node_id VARCHAR(64) NOT NULL, " +
+                    "file_id VARCHAR(128) NOT NULL, " +
+                    "PRIMARY KEY (plan_id, node_id, file_id))",
+            "CREATE TABLE IF NOT EXISTS mt_plan_activity (" +
+                    "plan_id VARCHAR(64) NOT NULL, " +
+                    "activity_id VARCHAR(64) NOT NULL, " +
+                    "activity_type VARCHAR(64) NOT NULL, " +
+                    "occurred_at TIMESTAMPTZ NOT NULL, " +
+                    "actor_id VARCHAR(64), " +
+                    "message_key VARCHAR(255), " +
+                    "reference_id VARCHAR(64), " +
+                    "attributes JSONB, " +
+                    "PRIMARY KEY (plan_id, activity_id))",
+            "CREATE TABLE IF NOT EXISTS mt_plan_reminder_rule (" +
+                    "plan_id VARCHAR(64) NOT NULL, " +
+                    "rule_id VARCHAR(64) NOT NULL, " +
+                    "trigger VARCHAR(64) NOT NULL, " +
+                    "offset_minutes INT NOT NULL, " +
+                    "channels JSONB, " +
+                    "template_id VARCHAR(64), " +
+                    "recipients JSONB, " +
+                    "description TEXT, " +
+                    "active BOOLEAN NOT NULL, " +
+                    "PRIMARY KEY (plan_id, rule_id))"
+    };
+
+    private static final String[] RESET_SEQUENCES = {
+            "ALTER SEQUENCE mt_plan_id_seq RESTART WITH 1",
+            "ALTER SEQUENCE mt_plan_node_id_seq RESTART WITH 1",
+            "ALTER SEQUENCE mt_plan_reminder_id_seq RESTART WITH 1"
+    };
+
+    private static final List<String> TABLES = List.of(
+            "mt_plan_activity",
+            "mt_plan_node_attachment",
+            "mt_plan_node_execution",
+            "mt_plan_node",
+            "mt_plan_participant",
+            "mt_plan_reminder_rule",
+            "mt_plan"
+    );
+
+    private PlanPersistenceTestDatabase() {
+    }
+
+    static void initializeSchema(JdbcTemplate jdbcTemplate) {
+        runStatements(jdbcTemplate, DROP_STATEMENTS);
+        runStatements(jdbcTemplate, CREATE_STATEMENTS);
+    }
+
+    static void cleanDatabase(JdbcTemplate jdbcTemplate) {
+        for (String table : TABLES) {
+            jdbcTemplate.execute("DELETE FROM " + table);
+        }
+        runStatements(jdbcTemplate, RESET_SEQUENCES);
+    }
+
+    static long countRows(JdbcTemplate jdbcTemplate, String table) {
+        return jdbcTemplate.queryForObject("SELECT COUNT(1) FROM " + table, Long.class);
+    }
+
+    static List<String> tableNames() {
+        return TABLES;
+    }
+
+    private static void runStatements(JdbcTemplate jdbcTemplate, String[] statements) {
+        for (String statement : statements) {
+            jdbcTemplate.execute(statement);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable helper to create and reset the PostgreSQL schema for persistence integration tests
- switch the plan repository test to use the shared helper utilities
- convert the analytics repository test into a PostgreSQL-backed integration test that checks parity with the in-memory analytics implementation

## Testing
- ⚠️ `mvn -f backend/pom.xml test` *(fails: cannot download Spring Boot parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1c2af038832f8bd82aca76ece0d0