### PR TITLE
Align Flyway migrations and extend plan SQL tests

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -26,6 +26,7 @@ spring:
     enabled: true
     locations: classpath:db/migration
     baseline-on-migrate: true
+    clean-disabled: true
 mybatis:
   mapper-locations: classpath:/mapper/*.xml
   type-handlers-package: com.bob.mta.common.mybatis

--- a/backend/src/main/resources/db/migration/V3__plan_indexes.sql
+++ b/backend/src/main/resources/db/migration/V3__plan_indexes.sql
@@ -1,5 +1,5 @@
 -- -----------------------------------------------------------------------------
--- Flyway V2 - Additional indexes to support analytics and reminders queries
+-- Flyway V3 - Additional indexes to support analytics and reminders queries
 -- -----------------------------------------------------------------------------
 
 CREATE INDEX IF NOT EXISTS idx_mt_plan_tenant_owner_end ON mt_plan (tenant_id, owner_id, planned_end_time);

--- a/backend/src/main/resources/db/migration/V4__plan_filter_indexes.sql
+++ b/backend/src/main/resources/db/migration/V4__plan_filter_indexes.sql
@@ -1,5 +1,5 @@
 -- -----------------------------------------------------------------------------
--- Flyway V3 - Extended filter indexes for tenant/customer analytics
+-- Flyway V4 - Extended filter indexes for tenant/customer analytics
 -- -----------------------------------------------------------------------------
 
 CREATE INDEX IF NOT EXISTS idx_mt_plan_tenant_customer_start ON mt_plan (tenant_id, customer_id, planned_start_time);

--- a/backend/src/main/resources/db/schema.sql
+++ b/backend/src/main/resources/db/schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS mt_plan (
     reminder_updated_by  VARCHAR(64)
 );
 
+-- 计划筛选与统计常用索引 ------------------------------------------------------
 CREATE INDEX IF NOT EXISTS idx_mt_plan_tenant_status ON mt_plan (tenant_id, status);
 CREATE INDEX IF NOT EXISTS idx_mt_plan_tenant_start ON mt_plan (tenant_id, planned_start_time);
 CREATE INDEX IF NOT EXISTS idx_mt_plan_tenant_end ON mt_plan (tenant_id, planned_end_time);


### PR DESCRIPTION
## Summary
- document the Flyway auto-migration workflow and manual schema/data scripts in the README
- harden Flyway by disabling clean, fix migration numbering conflicts, and annotate schema indexes
- extend plan persistence integration coverage with keyword/exclusion filtering over Testcontainers

## Testing
- mvn -f backend/pom.xml test *(fails: Maven Central returns 403 in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd48eb6f84832fb5ad3fefa5c62c54