### PR TITLE
Align plan persistence with PostgreSQL configuration

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanPersistenceConfiguration.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanPersistenceConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -34,6 +35,7 @@ import javax.sql.DataSource;
 public class PlanPersistenceConfiguration {
 
     @Bean
+    @Primary
     @ConfigurationProperties(prefix = "spring.datasource")
     @ConditionalOnMissingBean
     public DataSourceProperties planDataSourceProperties() {
@@ -41,6 +43,7 @@ public class PlanPersistenceConfiguration {
     }
 
     @Bean
+    @Primary
     @ConditionalOnMissingBean(DataSource.class)
     @ConditionalOnProperty(prefix = "spring.datasource", name = "url")
     public DataSource planDataSource(DataSourceProperties properties) {
@@ -48,6 +51,7 @@ public class PlanPersistenceConfiguration {
     }
 
     @Bean
+    @Primary
     @ConditionalOnBean(DataSource.class)
     @ConditionalOnMissingBean(PlatformTransactionManager.class)
     public PlatformTransactionManager planTransactionManager(DataSource dataSource) {
@@ -55,8 +59,9 @@ public class PlanPersistenceConfiguration {
     }
 
     @Bean
+    @Primary
     @ConditionalOnBean(DataSource.class)
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(JdbcTemplate.class)
     public JdbcTemplate jdbcTemplate(DataSource dataSource) {
         return new JdbcTemplate(dataSource);
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,10 +2,10 @@ spring:
   application:
     name: bob-mta-backend
   datasource:
-    url: jdbc:postgresql://localhost:5432/bobmta
-    username: bobmta
-    password: change-me
-    driver-class-name: org.postgresql.Driver
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/bobmta}
+    username: ${SPRING_DATASOURCE_USERNAME:bobmta}
+    password: ${SPRING_DATASOURCE_PASSWORD:change-me}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.postgresql.Driver}
   transaction:
     default-timeout: 30s
   jackson:

--- a/backend/src/main/resources/db/data.sql
+++ b/backend/src/main/resources/db/data.sql
@@ -69,7 +69,7 @@ ON CONFLICT DO NOTHING;
 
 INSERT INTO mt_plan_reminder_rule (plan_id, rule_id, trigger, offset_minutes, channels, template_id, recipients, description, active)
 VALUES
-    ('PLAN-00000001', 'REM-00000001', 'BEFORE_START', 60, '["EMAIL"]', 'tmpl-plan-reminder', '["owner-alpha","user-ops-001"]', '开工前一小时提醒执行人', TRUE),
-    ('PLAN-00000002', 'REM-00000002', 'AFTER_NODE', 15, '["EMAIL","IM"]', 'tmpl-node-reminder', '["owner-beta"]', '节点完成后通知负责人', TRUE),
+    ('PLAN-00000001', 'REM-00000001', 'BEFORE_PLAN_START', 60, '["EMAIL"]', 'tmpl-plan-reminder', '["owner-alpha","user-ops-001"]', '开工前一小时提醒执行人', TRUE),
+    ('PLAN-00000002', 'REM-00000002', 'BEFORE_PLAN_END', 15, '["EMAIL","IM"]', 'tmpl-node-reminder', '["owner-beta"]', '节点完成后通知负责人', TRUE),
     ('PLAN-00000004', 'REM-00000003', 'BEFORE_PLAN_START', 120, '["EMAIL","SMS"]', 'tmpl-plan-precheck', '["owner-delta","user-ops-006"]', '计划开始前两小时提醒全员', TRUE)
 ON CONFLICT DO NOTHING;

--- a/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistenceAnalyticsRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistenceAnalyticsRepositoryIntegrationTest.java
@@ -271,7 +271,7 @@ class PlanPersistenceAnalyticsRepositoryIntegrationTest {
         );
         PlanReminderRule reminderRule = new PlanReminderRule(
                 planRepository.nextReminderId(),
-                PlanReminderTrigger.BEFORE_START,
+                PlanReminderTrigger.BEFORE_PLAN_START,
                 60,
                 List.of("EMAIL", "SMS"),
                 "template-start",

--- a/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepositoryTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/repository/PlanPersistencePlanRepositoryTest.java
@@ -101,7 +101,7 @@ class PlanPersistencePlanRepositoryTest {
         PlanActivity activity = new PlanActivity(PlanActivityType.PLAN_CREATED, now.minusMinutes(30),
                 "system", "plan.created", "ref-1", Map.of("source", "test"));
 
-        PlanReminderRule rule = new PlanReminderRule(reminderId, PlanReminderTrigger.BEFORE_START, 45,
+        PlanReminderRule rule = new PlanReminderRule(reminderId, PlanReminderTrigger.BEFORE_PLAN_START, 45,
                 List.of("EMAIL", "SMS"), "template-1", List.of("user-1", "user-2"),
                 "Primary reminder", true);
         PlanReminderPolicy policy = new PlanReminderPolicy(List.of(rule), now.minusMinutes(45), "scheduler");
@@ -138,7 +138,7 @@ class PlanPersistencePlanRepositoryTest {
         assertThat(persistedPolicy.getRules()).hasSize(1);
         PlanReminderRule persistedRule = persistedPolicy.getRules().get(0);
         assertThat(persistedRule.getId()).isEqualTo(reminderId);
-        assertThat(persistedRule.getTrigger()).isEqualTo(PlanReminderTrigger.BEFORE_START);
+        assertThat(persistedRule.getTrigger()).isEqualTo(PlanReminderTrigger.BEFORE_PLAN_START);
         assertThat(persistedRule.getChannels()).containsExactly("EMAIL", "SMS");
         assertThat(persistedRule.getRecipients()).containsExactly("user-1", "user-2");
     }
@@ -160,7 +160,7 @@ class PlanPersistencePlanRepositoryTest {
                 null, PlanNodeActionType.NONE, 100, null, "Updated", List.of());
         PlanNodeExecution execution = new PlanNodeExecution(newNodeId, PlanNodeStatus.DONE,
                 now, now.plusHours(1), "owner-2", "done", null, List.of());
-        PlanReminderRule rule = new PlanReminderRule(repository.nextReminderId(), PlanReminderTrigger.BEFORE_END, 15,
+        PlanReminderRule rule = new PlanReminderRule(repository.nextReminderId(), PlanReminderTrigger.BEFORE_PLAN_END, 15,
                 List.of("EMAIL"), null, List.of(), "Updated rule", false);
         PlanReminderPolicy reminderPolicy = new PlanReminderPolicy(List.of(rule), now, "owner-2");
         Plan updatedPlan = new Plan(planId, "tenant-1", "Initial", "Updated description",

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/bobmta_test
-    username: bobmta
-    password: secret
-    driver-class-name: org.postgresql.Driver
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/bobmta_test}
+    username: ${SPRING_DATASOURCE_USERNAME:bobmta}
+    password: ${SPRING_DATASOURCE_PASSWORD:secret}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.postgresql.Driver}
   sql:
     init:
       mode: never


### PR DESCRIPTION
## Summary
- mark the plan persistence DataSource, transaction manager, and JdbcTemplate beans as primary for PostgreSQL-backed usage
- parameterize datasource credentials in the default and test application YAML files for container-based environments
- align reminder trigger seed data and repository integration tests with the PlanReminderTrigger enum naming

## Testing
- mvn -DskipTests package *(fails: cannot download spring-boot-starter-parent due to repository 403 in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dd48ef1d50832f89ecbb90c3ead5b5