### PR TITLE
feat(frontend): align plan preview mode handling

### DIFF
--- a/frontend/src/components/PlanPreview.tsx
+++ b/frontend/src/components/PlanPreview.tsx
@@ -103,7 +103,24 @@ export function PlanPreview({
   const detailStatus = isActiveDetail ? detailState.status : 'idle';
   const detailError = isActiveDetail ? detailState.error : null;
   const detailOrigin = isActiveDetail ? detailState.origin : null;
-  const previewContext = isActiveDetail ? detailState.context : deriveFallbackContext(plan);
+  const previewContext = useMemo<PlanDetailState['context']>(() => {
+    if (detail) {
+      const detailMode = PLAN_STATUS_MODE[detail.status];
+      const context = detailState.context;
+      if (
+        context.planStatus !== detail.status ||
+        context.mode !== detailMode
+      ) {
+        return {
+          planStatus: detail.status,
+          mode: detailMode,
+          currentNodeId: context.currentNodeId,
+        };
+      }
+      return context;
+    }
+    return deriveFallbackContext(plan);
+  }, [detail, detailState.context, plan]);
   const { mode, currentNodeId } = previewContext;
   const [editingNodeId, setEditingNodeId] = useState<string | null>(null);
   const modeSections = MODE_SECTION_CONFIG[mode];

--- a/frontend/src/state/planDetail.tsx
+++ b/frontend/src/state/planDetail.tsx
@@ -83,6 +83,14 @@ export type PlanDetailController = {
   setTimelineCategoryFilter: (category: string | null) => void;
 };
 
+export function selectPlanDetailMode(state: PlanDetailState): PlanViewMode {
+  return state.mode;
+}
+
+export function selectPlanDetailCurrentNodeId(state: PlanDetailState): string | null {
+  return state.currentNodeId;
+}
+
 export type PlanNodeActionInput =
   | {
       planId: string;

--- a/frontend/tests/planDetailState.test.mjs
+++ b/frontend/tests/planDetailState.test.mjs
@@ -123,6 +123,21 @@ test('derivePlanDetailContext switches mode when plan moves from design to execu
   assert.equal(executionContext.currentNodeId, 'NODE-2');
 });
 
+test('derivePlanDetailContext keeps execution mode but clears current node when cancelled plan is fully completed', () => {
+  const context = derivePlanDetailContext(
+    createDetail({
+      status: 'CANCELLED',
+      nodes: [
+        { id: 'NODE-1', name: 'Done Node', order: 1, status: 'DONE', actionType: 'MANUAL' },
+        { id: 'NODE-2', name: 'Skipped Node', order: 2, status: 'SKIPPED', actionType: 'MANUAL' },
+      ],
+    })
+  );
+
+  assert.equal(context.mode, 'execution');
+  assert.equal(context.currentNodeId, null);
+});
+
 test('derivePlanDetailContext defaults to design mode when detail is missing', () => {
   const context = derivePlanDetailContext(null);
 


### PR DESCRIPTION
## Summary
- derive the plan preview mode directly from the plan detail status so sections, node tree, and action panels react to design/execution transitions
- expose selectors for the plan detail mode and current node id and extend node context tests for cancelled plans

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddace5f3a8832f80b8bf10f6ec44db