### PR TITLE
Reuse precomputed plan calendar buckets

### DIFF
--- a/frontend/src/components/PlanCalendarView.tsx
+++ b/frontend/src/components/PlanCalendarView.tsx
@@ -31,6 +31,7 @@ type CalendarMode = 'month' | 'year';
 export type PlanCalendarViewProps = {
   plans?: PlanSummary[];
   events?: PlanCalendarEvent[];
+  buckets?: PlanCalendarBucket[];
   translate: LocalizationState['translate'];
   wrapWithCard?: boolean;
 };
@@ -38,6 +39,7 @@ export type PlanCalendarViewProps = {
 export function PlanCalendarView({
   plans,
   events,
+  buckets: prefetchedBuckets,
   translate,
   wrapWithCard = true,
 }: PlanCalendarViewProps) {
@@ -70,10 +72,16 @@ export function PlanCalendarView({
     [calendarEvents]
   );
 
-  const buckets = useMemo(
-    () => groupCalendarEvents(calendarEvents, { granularity }),
-    [calendarEvents, granularity]
-  );
+  const buckets = useMemo(() => {
+    if (
+      prefetchedBuckets &&
+      prefetchedBuckets.length > 0 &&
+      prefetchedBuckets.every((bucket) => bucket.granularity === granularity)
+    ) {
+      return prefetchedBuckets;
+    }
+    return groupCalendarEvents(calendarEvents, { granularity });
+  }, [calendarEvents, granularity, prefetchedBuckets]);
 
   const granularityLabel = useMemo(() => {
     const option = granularityOptions.find((item) => item.value === granularity);

--- a/frontend/src/components/PlanListBoard.tsx
+++ b/frontend/src/components/PlanListBoard.tsx
@@ -199,6 +199,7 @@ export function PlanListBoard({
     <PlanCalendarView
       translate={translate}
       events={planState.calendarEvents}
+      buckets={planState.calendarBuckets}
       plans={planState.records}
       wrapWithCard={false}
     />


### PR DESCRIPTION
## Summary
- allow `PlanCalendarView` to reuse prefetched calendar buckets when they match the selected granularity
- pass the derived calendar buckets from `PlanListBoard` to the calendar view so list state reuses cached aggregation

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68ddace4c810832f94b2503f1e86ed7f