### PR TITLE
Improve header brand navigation behavior

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -598,6 +598,10 @@ function AppView({ client, localization, session, navigation, planList, planDeta
 
   const menuSelectedKeys = activeMenuKey ? [activeMenuKey] : [];
 
+  const handleBrandNavigateHome = useCallback(() => {
+    navigate({ pathname: '/' });
+  }, [navigate]);
+
   const userDisplayName = sessionState.session?.displayName ?? translate('navUserGuest');
   const userInitial = useMemo(() => {
     if (!sessionState.session) {
@@ -646,6 +650,8 @@ function AppView({ client, localization, session, navigation, planList, planDeta
         localeOptions={localeOptions}
         localeLoading={loading}
         onLocaleChange={(value) => setLocale(value as Locale)}
+        brandHref="/"
+        onBrandClick={handleBrandNavigateHome}
         menuItems={isAuthenticated ? headerMenuItems : []}
         menuSelectedKeys={isAuthenticated ? menuSelectedKeys : undefined}
         onMenuClick={handleMenuClick}
@@ -653,7 +659,7 @@ function AppView({ client, localization, session, navigation, planList, planDeta
         isAuthenticated={isAuthenticated}
         userInitial={userInitial}
         userDisplayName={userDisplayName}
-        userRoles={sessionState.permissions.roles}
+        userRoles={sessionState.permissions.normalizedRoles}
         userMenuItems={sessionUserMenuItems}
         onUserMenuClick={handleUserMenuClick}
         onLoginClick={handleLoginShortcut}

--- a/frontend/src/components/HeaderNav.tsx
+++ b/frontend/src/components/HeaderNav.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from '../../vendor/react/index.js';
+import React, { useCallback, useMemo } from '../../vendor/react/index.js';
 import {
   Button,
   Dropdown,
@@ -25,6 +25,8 @@ type HeaderNavProps = {
   subtitle: string;
   localeLabel: string;
   loginLabel: string;
+  brandHref?: string;
+  onBrandClick?: () => void;
   localeValue: string;
   localeOptions: Array<{ label: string; value: string }>;
   localeLoading: boolean;
@@ -47,6 +49,8 @@ export function HeaderNav({
   subtitle,
   localeLabel,
   loginLabel,
+  brandHref = '/',
+  onBrandClick,
   localeValue,
   localeOptions,
   localeLoading,
@@ -118,10 +122,21 @@ export function HeaderNav({
     ? `${primaryRole}${secondaryRoleCount > 0 ? ` +${secondaryRoleCount}` : ''}`
     : null;
 
+  const handleBrandClick = useCallback(
+    (event: Event) => {
+      if (!onBrandClick) {
+        return;
+      }
+      event.preventDefault();
+      onBrandClick();
+    },
+    [onBrandClick]
+  );
+
   return (
     <Header className="app-header">
       <div className="app-header-left">
-        <a className="app-brand" href="/" aria-label={title}>
+        <a className="app-brand" href={brandHref} aria-label={title} onClick={handleBrandClick}>
           <div className="app-brand-mark" aria-hidden="true">
             <span className="app-brand-logo">BOB</span>
           </div>


### PR DESCRIPTION
## Summary
- allow the header brand link to call an optional click handler while retaining the default href fallback
- wire the app shell to reuse SPA navigation for the brand link and provide normalized roles to the header menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddcf41c408832fbb2e9302df4e05a1