### PR TITLE
Refine plan board aggregation sorting and extend tests

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/service/PlanBoardAggregator.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/service/PlanBoardAggregator.java
@@ -47,7 +47,13 @@ public final class PlanBoardAggregator {
                         ? PlanBoardView.UNKNOWN_CUSTOMER_ID
                         : plan.getCustomerId()));
         return grouped.entrySet().stream()
-                .sorted((left, right) -> Integer.compare(right.getValue().size(), left.getValue().size()))
+                .sorted((left, right) -> {
+                    int compare = Integer.compare(right.getValue().size(), left.getValue().size());
+                    if (compare != 0) {
+                        return compare;
+                    }
+                    return left.getKey().compareTo(right.getKey());
+                })
                 .map(entry -> toCustomerGroup(entry.getKey(), entry.getValue(), reference, dueSoonMinutes))
                 .toList();
     }


### PR DESCRIPTION
## Summary
- enforce deterministic ordering when aggregating customer groups on the plan board
- extend the in-memory service tests to cover customer sorting and status-filtered aggregation scenarios

## Testing
- `mvn test -Dtest=InMemoryPlanServiceTest#shouldSortCustomerGroupsByPlanCountAndId,InMemoryPlanServiceTest#shouldRespectStatusFiltersForPlanBoard` *(fails: dependency download blocked by repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68de0f532fe8832f8af34f563fd60b5f