### PR TITLE
Adjust plan board view rendering and calendar sync

### DIFF
--- a/docs/backend-requests/plan-board-view.md
+++ b/docs/backend-requests/plan-board-view.md
@@ -116,4 +116,4 @@
 ## 交付状态
 
 - ✅ 后端已在 `PlanService#getPlanBoard` 与 `PlanController#board` 提供实现，新增 SQL 聚合查询与未知客户分组逻辑，并补充单测与示例响应。
-- 🔄 前端可依据本文档调整 `PlanListBoard` 的请求逻辑与数据映射。
+- ✅ 前端 `PlanListBoard` 已提供 `Segmented` 视图切换，并通过 `PlanByCustomerView`、`PlanCalendarView` 显示客户分组与多粒度日历。派生逻辑在 `planList` 状态中复用后端返回的数据，缺失时会本地聚合以保持体验一致。

--- a/frontend/src/components/PlanCalendarView.tsx
+++ b/frontend/src/components/PlanCalendarView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from '../../vendor/react/index.js';
+import React, { useCallback, useEffect, useMemo, useState } from '../../vendor/react/index.js';
 import {
   Calendar,
   Card,
@@ -48,6 +48,18 @@ export function PlanCalendarView({
 }: PlanCalendarViewProps) {
   const [calendarMode, setCalendarMode] = useState<CalendarMode>('month');
   const [granularity, setGranularity] = useState<PlanCalendarGranularity>('month');
+
+  useEffect(() => {
+    setCalendarMode((current) => {
+      if (granularity === 'year' && current !== 'year') {
+        return 'year';
+      }
+      if (granularity !== 'year' && current !== 'month') {
+        return 'month';
+      }
+      return current;
+    });
+  }, [granularity]);
 
   const granularityOptions = useMemo(
     () => [

--- a/frontend/src/components/PlanListBoard.tsx
+++ b/frontend/src/components/PlanListBoard.tsx
@@ -6,7 +6,6 @@ import {
   Pagination,
   Segmented,
   Space,
-  Tabs,
   Table,
   Tag,
   Typography,
@@ -205,26 +204,17 @@ export function PlanListBoard({
     />
   );
 
-  const tabItems = useMemo(
-    () => [
-      {
-        key: 'table',
-        label: translate('planSectionTitle'),
-        children: tableView,
-      },
-      {
-        key: 'customer',
-        label: translate('planDetailCustomerLabel'),
-        children: customerView,
-      },
-      {
-        key: 'calendar',
-        label: translate('planDetailTimelineTitle'),
-        children: calendarView,
-      },
-    ],
-    [calendarView, customerView, tableView, translate]
-  );
+  const viewContent = useMemo(() => {
+    switch (viewMode) {
+      case 'customer':
+        return customerView;
+      case 'calendar':
+        return calendarView;
+      case 'table':
+      default:
+        return tableView;
+    }
+  }, [calendarView, customerView, tableView, viewMode]);
 
   return (
     <Card
@@ -291,13 +281,7 @@ export function PlanListBoard({
             errorDetail={errorDetailMessage}
             emptyHint={emptyHint}
           >
-            <Tabs
-              activeKey={viewMode}
-              items={tabItems}
-              onChange={(key: string) => {
-                onChangeViewMode(key as PlanListViewMode);
-              }}
-            />
+            {viewContent}
           </RemoteState>
         </Space>
       )}


### PR DESCRIPTION
## Summary
- replace the plan board tab control with segmented-driven content rendering so table, customer, and calendar views reuse the same filter context
- sync calendar mode with the selected granularity to keep month/year panels aligned in the calendar view
- update the board documentation to reflect the available frontend views and fallback aggregation behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de2bc90434832f9f1d487e9683be43