### PR TITLE
Support multi-customer plan board filtering

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanQueryParameters.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/persistence/PlanQueryParameters.java
@@ -9,6 +9,7 @@ import java.util.List;
 public record PlanQueryParameters(
         String tenantId,
         String customerId,
+        List<String> customerIds,
         String owner,
         String keyword,
         PlanStatus status,
@@ -21,7 +22,7 @@ public record PlanQueryParameters(
 ) {
 
     public static PlanQueryParameters empty() {
-        return new PlanQueryParameters(null, null, null, null, null, List.of(), null, null, null, null, null);
+        return new PlanQueryParameters(null, null, List.of(), null, null, List.of(), null, null, null, null, null);
     }
 
     public static PlanQueryParameters fromCriteria(PlanSearchCriteria criteria) {
@@ -31,6 +32,7 @@ public record PlanQueryParameters(
         return new PlanQueryParameters(
                 criteria.getTenantId(),
                 criteria.getCustomerId(),
+                criteria.getCustomerIds(),
                 criteria.getOwner(),
                 criteria.getKeyword(),
                 criteria.getStatus(),

--- a/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanBoardWindow.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanBoardWindow.java
@@ -59,8 +59,11 @@ public final class PlanBoardWindow {
                 .from(from)
                 .to(to)
                 .statuses(statuses.isEmpty() ? null : statuses);
-        if (customerIds.size() == 1) {
-            builder.customerId(customerIds.get(0));
+        if (!customerIds.isEmpty()) {
+            builder.customerIds(customerIds);
+            if (customerIds.size() == 1) {
+                builder.customerId(customerIds.get(0));
+            }
         }
         return builder.build();
     }

--- a/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanSearchCriteria.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/repository/PlanSearchCriteria.java
@@ -13,6 +13,7 @@ public final class PlanSearchCriteria {
     private final String keyword;
     private final PlanStatus status;
     private final List<PlanStatus> statuses;
+    private final List<String> customerIds;
     private final OffsetDateTime from;
     private final OffsetDateTime to;
     private final Integer limit;
@@ -21,13 +22,24 @@ public final class PlanSearchCriteria {
 
     private PlanSearchCriteria(Builder builder) {
         this.tenantId = builder.tenantId;
-        this.customerId = builder.customerId;
+        String resolvedCustomerId = builder.customerId;
         this.owner = builder.owner;
         this.keyword = builder.keyword;
         this.status = builder.status;
         this.statuses = builder.statuses != null
                 ? builder.statuses
                 : (builder.status == null ? List.of() : List.of(builder.status));
+        if (builder.customerIds != null) {
+            this.customerIds = List.copyOf(builder.customerIds);
+            if (resolvedCustomerId == null && this.customerIds.size() == 1) {
+                resolvedCustomerId = this.customerIds.get(0);
+            }
+        } else if (builder.customerId != null) {
+            this.customerIds = List.of(builder.customerId);
+        } else {
+            this.customerIds = List.of();
+        }
+        this.customerId = resolvedCustomerId;
         this.from = builder.from;
         this.to = builder.to;
         this.limit = builder.limit;
@@ -45,6 +57,10 @@ public final class PlanSearchCriteria {
 
     public String getCustomerId() {
         return customerId;
+    }
+
+    public List<String> getCustomerIds() {
+        return customerIds;
     }
 
     public String getOwner() {
@@ -91,6 +107,7 @@ public final class PlanSearchCriteria {
         private String keyword;
         private PlanStatus status;
         private List<PlanStatus> statuses;
+        private List<String> customerIds;
         private OffsetDateTime from;
         private OffsetDateTime to;
         private Integer limit;
@@ -107,6 +124,17 @@ public final class PlanSearchCriteria {
 
         public Builder customerId(String customerId) {
             this.customerId = customerId;
+            return this;
+        }
+
+        public Builder customerIds(List<String> customerIds) {
+            if (customerIds == null) {
+                this.customerIds = null;
+            } else {
+                this.customerIds = customerIds.stream()
+                        .filter(value -> value != null && !value.isBlank())
+                        .toList();
+            }
             return this;
         }
 

--- a/backend/src/main/resources/mapper/PlanAggregateMapper.xml
+++ b/backend/src/main/resources/mapper/PlanAggregateMapper.xml
@@ -191,7 +191,13 @@
             <if test="tenantId != null">
                 tenant_id = #{tenantId}
             </if>
-            <if test="customerId != null">
+            <if test="customerIds != null and !customerIds.isEmpty()">
+                AND customer_id IN
+                <foreach collection="customerIds" item="cid" open="(" separator="," close=")">
+                    #{cid}
+                </foreach>
+            </if>
+            <if test="(customerIds == null or customerIds.isEmpty()) and customerId != null">
                 AND customer_id = #{customerId}
             </if>
             <if test="owner != null">
@@ -238,7 +244,13 @@
             <if test="tenantId != null">
                 tenant_id = #{tenantId}
             </if>
-            <if test="customerId != null">
+            <if test="customerIds != null and !customerIds.isEmpty()">
+                AND customer_id IN
+                <foreach collection="customerIds" item="cid" open="(" separator="," close=")">
+                    #{cid}
+                </foreach>
+            </if>
+            <if test="(customerIds == null or customerIds.isEmpty()) and customerId != null">
                 AND customer_id = #{customerId}
             </if>
             <if test="owner != null">


### PR DESCRIPTION
## Summary
- extend plan search criteria and persistence parameters to carry multiple customer identifiers
- adjust in-memory filtering and SQL mappers so plan listings and board aggregates honour multi-customer scopes
- add repository regression coverage for multi-customer filtering and align the test helper

## Testing
- mvn -q -Dtest=PlanPersistencePlanRepositoryTest test *(fails: unable to resolve Spring Boot parent from Maven Central in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de2bc15f50832f93560e0fe43c1acb