### PR TITLE
Add link action automation coverage

### DIFF
--- a/docs/backend-requests/plan-node-operations.md
+++ b/docs/backend-requests/plan-node-operations.md
@@ -14,8 +14,8 @@
 ### 节点动作自动化
 
 - 当节点处于 `EMAIL`、`IM`、`LINK` 或 `REMOTE` 类型时，`PlanService` 会在 `startNode`/`completeNode`/`handoverNode` 流程中调用模板服务渲染上下文（计划ID、计划状态、节点名称、节点责任人、操作者、触发来源、执行结果等），随后通过通知网关派发邮件或即时消息，或生成用于远程/链接类动作的目标地址。
-- 每次自动化执行都会记录到新的 `PlanActionHistory` 仓储中，字段包括动作类型、模板引用、执行状态、上下文（计划/节点/操作者等）与错误信息，便于审计。
-- 时间线新增 `NODE_ACTION_EXECUTED` 事件，前端可依据 `actionStatus`、`actionMessage`、`actionError`、`meta.*`（模板/网关元数据、尝试次数、远程会话地址等）与 `context.*`（计划、节点、责任人、触发来源、执行结果等）属性展示成功/失败详情并支持筛选。
+- 每次自动化执行都会记录到新的 `PlanActionHistory` 仓储中，字段包括动作类型、模板引用、执行状态、上下文（计划/节点/操作者等）与错误信息，便于审计。`metadata` 字段会落盘模板与网关返回的详情，如 `attempts`（重试次数）、`endpoint`（链接或远程会话地址）、`artifactName`（远程脚本/附件名）、`provider`（邮件/IM 服务商）等，供运营追溯。
+- 时间线新增 `NODE_ACTION_EXECUTED` 事件，前端可依据 `actionStatus`、`actionMessage`、`actionError`、`meta.*`（模板/网关元数据、尝试次数、远程会话地址、生成的知识库链接等）与 `context.*`（计划、节点、责任人、触发来源、执行结果等）属性展示成功/失败详情并支持筛选。缺失链接的场景会返回 `actionStatus = SKIPPED` 并附带默认错误文案 `plan.error.nodeActionLinkMissing`，便于提示人工补录。
 - 当通知网关返回失败或模板渲染异常时，服务会按通道自动重试至多 3 次，若仍失败则以失败状态写入历史与时间线；计划状态更新仍会提交，便于前端提示并允许用户发起人工重试。
 
 ## 接口契约草案


### PR DESCRIPTION
## Summary
- add unit tests covering link-based node actions for success and skipped outcomes
- document metadata persisted in plan action history and timeline error messaging for missing links

## Testing
- `mvn -f backend/pom.xml test` *(fails: unable to download parent POM from Maven Central due to HTTP 403 in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de2bc0cd1c832f98790ddaa33b2155