### PR TITLE
test: extend plan list aggregations coverage

### DIFF
--- a/frontend/tests/planListAggregations.test.mjs
+++ b/frontend/tests/planListAggregations.test.mjs
@@ -293,3 +293,74 @@ test('getPlanCalendarEventAnchor/time prefer start then end timestamps', () => {
   assert.equal(getPlanCalendarEventAnchor(missingEvent), null);
   assert.equal(getPlanCalendarEventTime(missingEvent), Number.POSITIVE_INFINITY);
 });
+
+test('aggregatePlansByCustomer merges nameless identifiers ignoring casing and trims owners', () => {
+  const plans = [
+    createPlan('p-22', {
+      customer: { id: null, name: 'Northwind' },
+      customerId: null,
+      customerName: 'Northwind',
+      owner: '  Alice  ',
+      status: 'IN_PROGRESS',
+      progress: 35,
+    }),
+    createPlan('p-23', {
+      customer: { id: null, name: ' northwind  ' },
+      customerId: null,
+      customerName: ' northwind  ',
+      owner: 'diana',
+      status: 'COMPLETED',
+      progress: 90,
+    }),
+    createPlan('p-24', {
+      customer: { id: 'C-900', name: 'Contoso Labs' },
+      customerId: 'C-900',
+      customerName: 'Contoso Labs',
+      owner: 'bob',
+      status: 'DESIGN',
+      progress: 10,
+    }),
+  ];
+
+  const groups = aggregatePlansByCustomer(plans, { sortBy: 'name' });
+  assert.equal(groups.length, 2);
+
+  const northwind = groups.find((group) => group.customerName === 'Northwind');
+  assert.ok(northwind);
+  assert.equal(northwind.total, 2);
+  assert.deepEqual(northwind.owners, ['Alice', 'diana']);
+  assert.equal(Math.round(northwind.progressAverage ?? 0), 63);
+  assert.equal(northwind.statusCounts.IN_PROGRESS, 1);
+  assert.equal(northwind.statusCounts.COMPLETED, 1);
+
+  const contoso = groups.find((group) => group.customerId === 'C-900');
+  assert.ok(contoso);
+  assert.equal(contoso.total, 1);
+  assert.deepEqual(contoso.owners, ['bob']);
+});
+
+test('groupCalendarEvents skips invalid timestamps and preserves ordering', () => {
+  const validPlans = [
+    createPlan('p-25', {
+      plannedStartTime: '2025-08-01T10:00:00.000Z',
+      plannedEndTime: '2025-08-01T11:00:00.000Z',
+    }),
+    createPlan('p-26', {
+      plannedStartTime: '2025-08-03T12:00:00.000Z',
+      plannedEndTime: '2025-08-03T13:30:00.000Z',
+    }),
+  ];
+
+  const events = [
+    { plan: createPlan('invalid', {}), startTime: 'not-a-date', endTime: null, durationMinutes: null },
+    ...createPlanCalendarEvents(validPlans),
+  ];
+
+  const buckets = groupCalendarEvents(events, { granularity: 'month' });
+  assert.equal(buckets.length, 1);
+  assert.equal(buckets[0].events.length, 2);
+  assert.deepEqual(
+    buckets[0].events.map((event) => event.plan.id),
+    ['p-25', 'p-26']
+  );
+});


### PR DESCRIPTION
## Summary
- add regression coverage for customer grouping normalization to confirm whitespace and casing are handled consistently
- extend calendar bucketing tests to verify invalid timestamps are skipped and ordering is preserved

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68de3f9ae3a8832f97b8cecbee2db2de