### PR TITLE
Refine plan board view toggles

### DIFF
--- a/docs/backend-requests/plan-board-view.md
+++ b/docs/backend-requests/plan-board-view.md
@@ -124,4 +124,5 @@
 
 - ✅ 后端已在 `PlanService#getPlanBoard` 与 `PlanController#board` 提供实现，基于 `PlanSearchCriteria` 聚合客户/时间桶并记录审计快照，补充 SQL 聚合与未知客户分组逻辑及单测、示例响应。
 - ✅ 前端 `PlanListBoard` 已提供 `Segmented` 视图切换，并通过 `PlanByCustomerView`、`PlanCalendarView` 显示客户分组与多粒度日历。派生逻辑在 `planList` 状态中复用后端返回的数据，缺失时会本地聚合以保持体验一致。
+- ✅ 视图模式会同步至 URL 查询参数，刷新或分享页面时会自动还原 `Segmented`/`Tabs` 的选项，避免用户重复筛选。
 - ✅ 客户视图与日历视图会按计划时间排序展示卡片，新增的前端单元测试验证客户分组与时间桶聚合的稳定性，保证多视图切换时的顺序一致。

--- a/frontend/src/components/PlanCalendarView.tsx
+++ b/frontend/src/components/PlanCalendarView.tsx
@@ -152,7 +152,10 @@ export function PlanCalendarView({
       options={granularityOptions}
       onChange={(value) => {
         if (typeof value === 'string') {
-          setGranularity(value as PlanCalendarGranularity);
+          const nextGranularity = value as PlanCalendarGranularity;
+          if (nextGranularity !== granularity) {
+            setGranularity(nextGranularity);
+          }
         }
       }}
     />

--- a/frontend/src/components/PlanListBoard.tsx
+++ b/frontend/src/components/PlanListBoard.tsx
@@ -274,7 +274,10 @@ export function PlanListBoard({
               options={viewOptions}
               onChange={(value) => {
                 if (typeof value === 'string') {
-                  onChangeViewMode(value as PlanListViewMode);
+                  const nextMode = value as PlanListViewMode;
+                  if (nextMode !== viewMode) {
+                    onChangeViewMode(nextMode);
+                  }
                 }
               }}
             />

--- a/frontend/tests/planListAggregations.test.mjs
+++ b/frontend/tests/planListAggregations.test.mjs
@@ -107,6 +107,51 @@ test('aggregatePlansByCustomer sorts alphabetically when using name comparator',
   );
 });
 
+test('aggregatePlansByCustomer sorts by total ascending when descending disabled', () => {
+  const plans = [
+    createPlan('p-18a', {
+      customer: { id: 'c-18a', name: 'Contoso' },
+      customerId: 'c-18a',
+      customerName: 'Contoso',
+    }),
+    createPlan('p-18b', {
+      customer: { id: 'c-18b', name: 'Fabrikam' },
+      customerId: 'c-18b',
+      customerName: 'Fabrikam',
+    }),
+    createPlan('p-18c', {
+      customer: { id: 'c-18b', name: 'Fabrikam' },
+      customerId: 'c-18b',
+      customerName: 'Fabrikam',
+    }),
+    createPlan('p-18d', {
+      customer: null,
+      customerId: null,
+      customerName: null,
+    }),
+    createPlan('p-18e', {
+      customer: null,
+      customerId: null,
+      customerName: null,
+    }),
+    createPlan('p-18f', {
+      customer: null,
+      customerId: null,
+      customerName: null,
+    }),
+  ];
+
+  const groups = aggregatePlansByCustomer(plans, { sortBy: 'total', descending: false });
+  assert.deepEqual(
+    groups.map((group) => group.total),
+    [1, 2, 3]
+  );
+  assert.deepEqual(
+    groups.map((group) => group.customerName),
+    ['Contoso', 'Fabrikam', 'Unassigned']
+  );
+});
+
 test('aggregatePlansByCustomer merges case-insensitive names without identifiers', () => {
   const plans = [
     createPlan('p-22', {


### PR DESCRIPTION
## Summary
- avoid redundant plan list view mode updates when toggling between table, customer, and calendar tabs
- keep calendar granularity changes stable and expand aggregation tests plus documentation on URL persistence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df06a07d94832f912d1958d48d5a8b