### PR TITLE
Add action history identifier to timeline events

### DIFF
--- a/backend/src/main/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanService.java
+++ b/backend/src/main/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanService.java
@@ -1180,6 +1180,7 @@ public class InMemoryPlanService implements PlanService {
                 dispatchResult.metadata()
         );
         actionHistoryRepository.append(history);
+        attributes.put("actionId", history.getId());
         return new PlanActivity(
                 PlanActivityType.NODE_ACTION_EXECUTED,
                 occurredAt,

--- a/backend/src/test/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanServiceActionTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanServiceActionTest.java
@@ -131,6 +131,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionType", PlanNodeActionType.EMAIL.name())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("actionMessage", "email.sent")
@@ -160,6 +161,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.FAILED.name())
                 .containsEntry("actionError", "render failed")
                 .containsEntry("actionMessage", "plan.action.failed");
@@ -197,6 +199,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.FAILED.name())
                 .containsEntry("actionError", "gateway down")
                 .containsEntry("meta.attempts", "3")
@@ -233,6 +236,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("actionMessage", "im.sent")
                 .containsEntry("meta.channel", "mock");
@@ -266,6 +270,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("meta.endpoint", "https://remote.example.com/session")
                 .containsEntry("context.nodeAssignee", "frank")
@@ -291,6 +296,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.FAILED.name())
                 .containsEntry("actionError", "template missing")
                 .containsEntry("context.trigger", "handover")
@@ -338,6 +344,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("meta.endpoint", "https://hooks.example.com/workflow")
                 .containsEntry("meta.method", "PUT")
@@ -379,6 +386,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.FAILED.name())
                 .containsEntry("actionError", "api gateway down")
                 .containsEntry("meta.attempts", "3");
@@ -418,6 +426,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.FAILED.name())
                 .containsEntry("actionMessage", "plan.action.apiMissingEndpoint")
                 .containsEntry("actionError", messageResolver.getMessage("plan.error.nodeActionApiEndpointMissing"))
@@ -455,6 +464,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("meta.endpoint", "https://kb.example.com/task")
                 .containsEntry("meta.doc", "kb-article")
@@ -491,6 +501,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SKIPPED.name())
                 .containsEntry("actionMessage", "plan.action.linkMissing")
                 .containsEntry("actionError", messageResolver.getMessage("plan.error.nodeActionLinkMissing"));
@@ -516,6 +527,7 @@ class InMemoryPlanServiceActionTest {
 
         PlanActivity actionActivity = findActionActivity(updated);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionType", PlanNodeActionType.FILE.name())
                 .containsEntry("actionStatus", PlanActionStatus.SKIPPED.name())
                 .containsEntry("actionMessage", "plan.action.noAutomation")

--- a/backend/src/test/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanServiceTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/plan/service/impl/InMemoryPlanServiceTest.java
@@ -925,6 +925,7 @@ class InMemoryPlanServiceTest {
         PlanActivity actionActivity = latestActivity(updated, PlanActivityType.NODE_ACTION_EXECUTED);
         assertThat(actionActivity).isNotNull();
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("meta.templateId", String.valueOf(templateId))
                 .containsEntry("meta.attempts", "1")
@@ -962,6 +963,7 @@ class InMemoryPlanServiceTest {
 
         PlanActivity actionActivity = latestActivity(updated, PlanActivityType.NODE_ACTION_EXECUTED);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.FAILED.name())
                 .containsEntry("actionError", "smtp-down")
                 .containsEntry("meta.attempts", "3");
@@ -999,6 +1001,7 @@ class InMemoryPlanServiceTest {
 
         PlanActivity actionActivity = latestActivity(completed, PlanActivityType.NODE_ACTION_EXECUTED);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("actionTrigger", "complete")
                 .containsEntry("meta.attempts", "1");
@@ -1035,6 +1038,7 @@ class InMemoryPlanServiceTest {
 
         PlanActivity actionActivity = latestActivity(updated, PlanActivityType.NODE_ACTION_EXECUTED);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("meta.attempts", "2");
     }
@@ -1071,6 +1075,7 @@ class InMemoryPlanServiceTest {
 
         PlanActivity actionActivity = latestActivity(updated, PlanActivityType.NODE_ACTION_EXECUTED);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("meta.endpoint", "https://remote.example/session")
                 .containsEntry("meta.attempts", "1")
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name());
@@ -1127,6 +1132,7 @@ class InMemoryPlanServiceTest {
 
         PlanActivity actionActivity = latestActivity(completed, PlanActivityType.NODE_ACTION_EXECUTED);
         assertThat(actionActivity.getAttributes())
+                .containsEntry("actionId", history.getId())
                 .containsEntry("actionStatus", PlanActionStatus.SUCCESS.name())
                 .containsEntry("meta.endpoint", "https://hooks.internal/api")
                 .containsEntry("meta.method", "PATCH")

--- a/docs/backend-requests/plan-node-operations.md
+++ b/docs/backend-requests/plan-node-operations.md
@@ -16,7 +16,7 @@
 - 当节点处于 `EMAIL`、`IM`、`LINK`、`REMOTE` 或 `API_CALL` 类型时，`PlanService` 会在 `startNode`/`completeNode`/`handoverNode` 流程中调用模板服务渲染上下文（计划ID、计划状态、节点名称、节点责任人、操作者、触发来源、执行结果等），随后通过通知网关派发邮件或即时消息，生成用于远程/链接类动作的目标地址，或向外部工作流/自动化平台发起 API 调用。
 - 每次自动化执行都会记录到新的 `PlanActionHistory` 仓储中，字段包括动作类型、模板引用、执行状态、上下文（计划/节点/操作者等）与错误信息，便于审计。`metadata` 字段会落盘模板与网关返回的详情，如 `attempts`（重试次数）、`endpoint`（链接或远程会话地址）、`artifactName`（远程脚本/附件名）、`provider`（邮件/IM 服务商）等，供运营追溯。
 - API 调用场景会将模板 `metadata` 中非敏感键（如 `method`、`scenario` 等）与通知网关返回值写入历史，并过滤掉以 `header.` 开头的敏感首部内容，最终在时间线中以 `meta.method`、`meta.endpoint`、`meta.status` 等字段供前端展示；若模板缺失 `endpoint` 则直接以失败写入历史并提示 `plan.error.nodeActionApiEndpointMissing`。
-- 时间线新增 `NODE_ACTION_EXECUTED` 事件，前端可依据 `actionStatus`、`actionMessage`、`actionError`、`meta.*`（模板/网关元数据、尝试次数、远程会话地址、生成的知识库链接等）与 `context.*`（计划、节点、责任人、触发来源、执行结果等）属性展示成功/失败详情并支持筛选。缺失链接的场景会返回 `actionStatus = SKIPPED` 并附带默认错误文案 `plan.error.nodeActionLinkMissing`，便于提示人工补录。
+- 时间线新增 `NODE_ACTION_EXECUTED` 事件，前端可依据 `actionStatus`、`actionMessage`、`actionError`、`meta.*`（模板/网关元数据、尝试次数、远程会话地址、生成的知识库链接等）与 `context.*`（计划、节点、责任人、触发来源、执行结果等）属性展示成功/失败详情并支持筛选；事件中新增的 `actionId` 字段与 `PlanActionHistory` 主键对齐，便于点击时间线直接跳转或请求完整历史记录。缺失链接的场景会返回 `actionStatus = SKIPPED` 并附带默认错误文案 `plan.error.nodeActionLinkMissing`，便于提示人工补录。
 - 当通知网关返回失败或模板渲染异常时，服务会按通道自动重试至多 3 次，若仍失败则以失败状态写入历史与时间线；计划状态更新仍会提交，便于前端提示并允许用户发起人工重试。
 - 当节点动作类型为 `FILE` 时，系统不会触发任何网关或模板渲染，执行会以 `actionStatus = SKIPPED` 写入动作历史与时间线，并在 `metadata.reason`
   字段标记 `NOT_SUPPORTED`，提醒操作者改为人工处理。

--- a/docs/backend-requests/plan-timeline-activities.md
+++ b/docs/backend-requests/plan-timeline-activities.md
@@ -41,7 +41,7 @@
 | `PLAN_HANDOVER` | `plan.activity.handover` | `oldOwner`、`newOwner`、`operator`、`participantCount`、`note` |
 | `NODE_STARTED` | `plan.activity.nodeStarted` | `nodeName`、`assignee`、`operator` |
 | `NODE_COMPLETED` | `plan.activity.nodeCompleted` | `nodeName`、`operator`、`result` |
-| `NODE_ACTION_EXECUTED` | `plan.activity.nodeActionExecuted` | `nodeName`、`actionType`、`actionStatus`、`actionMessage`、`actionTrigger`、`actionError` |
+| `NODE_ACTION_EXECUTED` | `plan.activity.nodeActionExecuted` | `nodeName`、`actionType`、`actionStatus`、`actionMessage`、`actionTrigger`、`actionError`、`actionId` |
 | `NODE_HANDOVER` | `plan.activity.nodeHandover` | `nodeName`、`previousAssignee`、`newAssignee`、`operator`、`comment` |
 | `NODE_AUTO_COMPLETED` | `plan.activity.nodeAutoCompleted` | `nodeName`、`threshold`、`completedChildren`、`totalChildren` |
 | `NODE_SKIPPED` | `plan.activity.nodeSkipped` | `nodeName`、`parentNodeId`、`parentNode` |


### PR DESCRIPTION
## Summary
- include the generated PlanActionHistory id in NODE_ACTION_EXECUTED timeline attributes so UI workflows can reference persisted records
- expand plan action automation tests across channels to assert the actionId attribute is present alongside existing metadata
- document the new actionId surface area for node automation timelines and history linking

## Testing
- `mvn test` *(fails: unable to download Spring Boot parent POM from Maven Central due to 403 response)*

------
https://chatgpt.com/codex/tasks/task_e_68df0609a264832fa628bf60b3613f97