### PR TITLE
feat: persist templates and add notification adapters

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,6 +27,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <version>8.5.7</version>

--- a/backend/src/main/java/com/bob/mta/BobMtaApplication.java
+++ b/backend/src/main/java/com/bob/mta/BobMtaApplication.java
@@ -1,6 +1,7 @@
 package com.bob.mta;
 
 import com.bob.mta.common.security.JwtProperties;
+import com.bob.mta.modules.notification.NotificationProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -13,7 +14,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
     DataSourceTransactionManagerAutoConfiguration.class,
     JdbcTemplateAutoConfiguration.class
 })
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, NotificationProperties.class})
 public class BobMtaApplication {
     public static void main(String[] args) {
         SpringApplication.run(BobMtaApplication.class, args);

--- a/backend/src/main/java/com/bob/mta/modules/notification/HttpApiNotificationAdapter.java
+++ b/backend/src/main/java/com/bob/mta/modules/notification/HttpApiNotificationAdapter.java
@@ -1,0 +1,91 @@
+package com.bob.mta.modules.notification;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestOperations;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+@Component
+@ConditionalOnProperty(prefix = "notification.api", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class HttpApiNotificationAdapter implements ApiNotificationAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpApiNotificationAdapter.class);
+
+    private final RestOperations restOperations;
+
+    public HttpApiNotificationAdapter(RestTemplateBuilder builder, NotificationProperties properties) {
+        NotificationProperties.Api config = properties.getApi();
+        Duration connectTimeout = config.getConnectTimeout() == null ? Duration.ofSeconds(5) : config.getConnectTimeout();
+        Duration readTimeout = config.getReadTimeout() == null ? Duration.ofSeconds(15) : config.getReadTimeout();
+        this.restOperations = builder
+                .setConnectTimeout(connectTimeout)
+                .setReadTimeout(readTimeout)
+                .build();
+    }
+
+    HttpApiNotificationAdapter(RestOperations restOperations) {
+        this.restOperations = restOperations;
+    }
+
+    @Override
+    public NotificationResult invoke(ApiCallRequest request) {
+        HttpMethod method = resolveMethod(request.getMethod());
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            if (request.getHeaders() != null) {
+                request.getHeaders().forEach(headers::add);
+            }
+            if (!headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
+                headers.setContentType(MediaType.APPLICATION_JSON);
+            }
+            HttpEntity<String> entity = new HttpEntity<>(request.getBody(), headers);
+            ResponseEntity<String> response = restOperations.exchange(request.getEndpoint(), method, entity, String.class);
+            int status = response.getStatusCode().value();
+            Map<String, String> metadata = new LinkedHashMap<>();
+            metadata.put("endpoint", request.getEndpoint());
+            metadata.put("status", String.valueOf(status));
+            if (StringUtils.hasText(response.getBody())) {
+                metadata.put("body", truncate(response.getBody()));
+            }
+            if (response.getStatusCode().is2xxSuccessful()) {
+                log.info("API call to {} succeeded with status {}", request.getEndpoint(), status);
+                return NotificationResult.success("API", "api.invoked", metadata);
+            }
+            log.warn("API call to {} failed with status {}", request.getEndpoint(), status);
+            return NotificationResult.failure("API", "api.failed", "HTTP status %d".formatted(status), metadata);
+        } catch (RestClientException ex) {
+            log.error("Failed to invoke API", ex);
+            return NotificationResult.failure("API", "api.failed", ex.getMessage(),
+                    Map.of("reason", "HTTP_ERROR"));
+        }
+    }
+
+    private HttpMethod resolveMethod(String method) {
+        if (!StringUtils.hasText(method)) {
+            return HttpMethod.POST;
+        }
+        HttpMethod resolved = HttpMethod.resolve(method.toUpperCase(Locale.ROOT));
+        return resolved == null ? HttpMethod.POST : resolved;
+    }
+
+    private String truncate(String body) {
+        if (body.length() <= 512) {
+            return body;
+        }
+        return body.substring(0, 512);
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/notification/LoggingApiNotificationAdapter.java
+++ b/backend/src/main/java/com/bob/mta/modules/notification/LoggingApiNotificationAdapter.java
@@ -2,6 +2,7 @@ package com.bob.mta.modules.notification;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
 import java.util.LinkedHashMap;
@@ -9,6 +10,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
+@ConditionalOnMissingBean(ApiNotificationAdapter.class)
 public class LoggingApiNotificationAdapter implements ApiNotificationAdapter {
 
     private static final Logger log = LoggerFactory.getLogger(LoggingApiNotificationAdapter.class);

--- a/backend/src/main/java/com/bob/mta/modules/notification/LoggingEmailNotificationAdapter.java
+++ b/backend/src/main/java/com/bob/mta/modules/notification/LoggingEmailNotificationAdapter.java
@@ -2,12 +2,14 @@ package com.bob.mta.modules.notification;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Component
+@ConditionalOnMissingBean(EmailNotificationAdapter.class)
 public class LoggingEmailNotificationAdapter implements EmailNotificationAdapter {
 
     private static final Logger log = LoggerFactory.getLogger(LoggingEmailNotificationAdapter.class);

--- a/backend/src/main/java/com/bob/mta/modules/notification/LoggingInstantMessageNotificationAdapter.java
+++ b/backend/src/main/java/com/bob/mta/modules/notification/LoggingInstantMessageNotificationAdapter.java
@@ -2,12 +2,14 @@ package com.bob.mta.modules.notification;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
+@ConditionalOnMissingBean(InstantMessageNotificationAdapter.class)
 public class LoggingInstantMessageNotificationAdapter implements InstantMessageNotificationAdapter {
 
     private static final Logger log = LoggerFactory.getLogger(LoggingInstantMessageNotificationAdapter.class);

--- a/backend/src/main/java/com/bob/mta/modules/notification/NotificationProperties.java
+++ b/backend/src/main/java/com/bob/mta/modules/notification/NotificationProperties.java
@@ -1,0 +1,127 @@
+package com.bob.mta.modules.notification;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "notification")
+public class NotificationProperties {
+
+    private final Email email = new Email();
+    private final InstantMessage instantMessage = new InstantMessage();
+    private final Api api = new Api();
+
+    public Email getEmail() {
+        return email;
+    }
+
+    public InstantMessage getInstantMessage() {
+        return instantMessage;
+    }
+
+    public Api getApi() {
+        return api;
+    }
+
+    public static class Email {
+
+        private boolean enabled;
+        private String from;
+        private String replyTo;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getFrom() {
+            return from;
+        }
+
+        public void setFrom(String from) {
+            this.from = from;
+        }
+
+        public String getReplyTo() {
+            return replyTo;
+        }
+
+        public void setReplyTo(String replyTo) {
+            this.replyTo = replyTo;
+        }
+    }
+
+    public static class InstantMessage {
+
+        private boolean enabled;
+        private String webhookUrl;
+        private Duration connectTimeout = Duration.ofSeconds(5);
+        private Duration readTimeout = Duration.ofSeconds(10);
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getWebhookUrl() {
+            return webhookUrl;
+        }
+
+        public void setWebhookUrl(String webhookUrl) {
+            this.webhookUrl = webhookUrl;
+        }
+
+        public Duration getConnectTimeout() {
+            return connectTimeout;
+        }
+
+        public void setConnectTimeout(Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+        }
+
+        public Duration getReadTimeout() {
+            return readTimeout;
+        }
+
+        public void setReadTimeout(Duration readTimeout) {
+            this.readTimeout = readTimeout;
+        }
+    }
+
+    public static class Api {
+
+        private boolean enabled = true;
+        private Duration connectTimeout = Duration.ofSeconds(5);
+        private Duration readTimeout = Duration.ofSeconds(15);
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public Duration getConnectTimeout() {
+            return connectTimeout;
+        }
+
+        public void setConnectTimeout(Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+        }
+
+        public Duration getReadTimeout() {
+            return readTimeout;
+        }
+
+        public void setReadTimeout(Duration readTimeout) {
+            this.readTimeout = readTimeout;
+        }
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/notification/SmtpEmailNotificationAdapter.java
+++ b/backend/src/main/java/com/bob/mta/modules/notification/SmtpEmailNotificationAdapter.java
@@ -1,0 +1,79 @@
+package com.bob.mta.modules.notification;
+
+import jakarta.mail.internet.MimeMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Primary
+@ConditionalOnBean(JavaMailSender.class)
+@ConditionalOnProperty(prefix = "notification.email", name = "enabled", havingValue = "true")
+public class SmtpEmailNotificationAdapter implements EmailNotificationAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(SmtpEmailNotificationAdapter.class);
+
+    private final JavaMailSender mailSender;
+    private final NotificationProperties properties;
+
+    public SmtpEmailNotificationAdapter(JavaMailSender mailSender, NotificationProperties properties) {
+        this.mailSender = mailSender;
+        this.properties = properties;
+    }
+
+    @Override
+    public NotificationResult send(EmailMessage message) {
+        NotificationProperties.Email config = properties.getEmail();
+        String from = config.getFrom();
+        if (!StringUtils.hasText(from)) {
+            return NotificationResult.failure("EMAIL", "email.configuration.missing-from",
+                    "Email sender address is not configured", Map.of());
+        }
+        List<String> toRecipients = message.getTo();
+        if (CollectionUtils.isEmpty(toRecipients)) {
+            return NotificationResult.failure("EMAIL", "email.configuration.missing-recipient",
+                    "Email recipient list is empty", Map.of("reason", "NO_RECIPIENT"));
+        }
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, StandardCharsets.UTF_8.name());
+            helper.setFrom(from);
+            if (StringUtils.hasText(config.getReplyTo())) {
+                helper.setReplyTo(config.getReplyTo());
+            }
+            helper.setTo(toRecipients.toArray(String[]::new));
+            if (!message.getCc().isEmpty()) {
+                helper.setCc(message.getCc().toArray(String[]::new));
+            }
+            helper.setSubject(message.getSubject());
+            helper.setText(message.getContent() == null ? "" : message.getContent(), true);
+
+            mailSender.send(mimeMessage);
+
+            Map<String, String> metadata = new LinkedHashMap<>();
+            metadata.put("from", from);
+            metadata.put("to", String.join(",", toRecipients));
+            if (!message.getCc().isEmpty()) {
+                metadata.put("cc", String.join(",", message.getCc()));
+            }
+            log.info("Email dispatched to {}", metadata.get("to"));
+            return NotificationResult.success("EMAIL", "email.dispatched", metadata);
+        } catch (Exception ex) {
+            log.error("Failed to send email via SMTP", ex);
+            return NotificationResult.failure("EMAIL", "email.dispatch.failed", ex.getMessage(),
+                    Map.of("reason", "SMTP_ERROR"));
+        }
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/notification/WebhookInstantMessageNotificationAdapter.java
+++ b/backend/src/main/java/com/bob/mta/modules/notification/WebhookInstantMessageNotificationAdapter.java
@@ -1,0 +1,81 @@
+package com.bob.mta.modules.notification;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestOperations;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+@ConditionalOnProperty(prefix = "notification.instant-message", name = "enabled", havingValue = "true")
+public class WebhookInstantMessageNotificationAdapter implements InstantMessageNotificationAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(WebhookInstantMessageNotificationAdapter.class);
+
+    private final RestOperations restOperations;
+    private final NotificationProperties properties;
+
+    public WebhookInstantMessageNotificationAdapter(RestTemplateBuilder builder, NotificationProperties properties) {
+        NotificationProperties.InstantMessage config = properties.getInstantMessage();
+        Duration connectTimeout = config.getConnectTimeout() == null ? Duration.ofSeconds(5) : config.getConnectTimeout();
+        Duration readTimeout = config.getReadTimeout() == null ? Duration.ofSeconds(10) : config.getReadTimeout();
+        this.restOperations = builder
+                .setConnectTimeout(connectTimeout)
+                .setReadTimeout(readTimeout)
+                .build();
+        this.properties = properties;
+    }
+
+    WebhookInstantMessageNotificationAdapter(RestOperations restOperations, NotificationProperties properties) {
+        this.restOperations = restOperations;
+        this.properties = properties;
+    }
+
+    @Override
+    public NotificationResult send(InstantMessage message) {
+        NotificationProperties.InstantMessage config = properties.getInstantMessage();
+        String webhookUrl = config.getWebhookUrl();
+        if (!StringUtils.hasText(webhookUrl)) {
+            return NotificationResult.failure("IM", "im.configuration.missing-webhook",
+                    "Instant message webhook URL is not configured", Map.of());
+        }
+        try {
+            Map<String, Object> payload = buildPayload(message);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            restOperations.postForEntity(webhookUrl, new HttpEntity<>(payload, headers), String.class);
+            Map<String, String> metadata = new LinkedHashMap<>();
+            metadata.put("webhook", webhookUrl);
+            metadata.put("recipients", String.join(",", message.getRecipients()));
+            log.info("Instant message dispatched to {}", metadata.get("recipients"));
+            return NotificationResult.success("IM", "im.dispatched", metadata);
+        } catch (RestClientException ex) {
+            log.error("Failed to send instant message", ex);
+            return NotificationResult.failure("IM", "im.dispatch.failed", ex.getMessage(),
+                    Map.of("reason", "WEBHOOK_ERROR"));
+        }
+    }
+
+    private Map<String, Object> buildPayload(InstantMessage message) {
+        Map<String, Object> text = new LinkedHashMap<>();
+        text.put("content", message.getContent());
+        if (!CollectionUtils.isEmpty(message.getRecipients())) {
+            text.put("mentioned_list", message.getRecipients());
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("msgtype", "text");
+        payload.put("text", text);
+        return payload;
+    }
+}

--- a/backend/src/main/java/com/bob/mta/modules/template/persistence/TemplateEntity.java
+++ b/backend/src/main/java/com/bob/mta/modules/template/persistence/TemplateEntity.java
@@ -4,6 +4,7 @@ import com.bob.mta.modules.template.domain.TemplateType;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class TemplateEntity {
 
@@ -13,6 +14,14 @@ public class TemplateEntity {
     private List<String> ccRecipients;
     private String endpoint;
     private boolean enabled;
+    private String nameDefaultLocale;
+    private Map<String, String> nameTranslations;
+    private String subjectDefaultLocale;
+    private Map<String, String> subjectTranslations;
+    private String contentDefaultLocale;
+    private Map<String, String> contentTranslations;
+    private String descriptionDefaultLocale;
+    private Map<String, String> descriptionTranslations;
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
 
@@ -20,13 +29,26 @@ public class TemplateEntity {
     }
 
     public TemplateEntity(Long id, TemplateType type, List<String> toRecipients, List<String> ccRecipients,
-                          String endpoint, boolean enabled, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+                          String endpoint, boolean enabled, String nameDefaultLocale,
+                          Map<String, String> nameTranslations, String subjectDefaultLocale,
+                          Map<String, String> subjectTranslations, String contentDefaultLocale,
+                          Map<String, String> contentTranslations, String descriptionDefaultLocale,
+                          Map<String, String> descriptionTranslations, OffsetDateTime createdAt,
+                          OffsetDateTime updatedAt) {
         this.id = id;
         this.type = type;
         this.toRecipients = toRecipients;
         this.ccRecipients = ccRecipients;
         this.endpoint = endpoint;
         this.enabled = enabled;
+        this.nameDefaultLocale = nameDefaultLocale;
+        this.nameTranslations = nameTranslations;
+        this.subjectDefaultLocale = subjectDefaultLocale;
+        this.subjectTranslations = subjectTranslations;
+        this.contentDefaultLocale = contentDefaultLocale;
+        this.contentTranslations = contentTranslations;
+        this.descriptionDefaultLocale = descriptionDefaultLocale;
+        this.descriptionTranslations = descriptionTranslations;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -77,6 +99,70 @@ public class TemplateEntity {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public String getNameDefaultLocale() {
+        return nameDefaultLocale;
+    }
+
+    public void setNameDefaultLocale(String nameDefaultLocale) {
+        this.nameDefaultLocale = nameDefaultLocale;
+    }
+
+    public Map<String, String> getNameTranslations() {
+        return nameTranslations == null ? Map.of() : nameTranslations;
+    }
+
+    public void setNameTranslations(Map<String, String> nameTranslations) {
+        this.nameTranslations = nameTranslations == null ? Map.of() : Map.copyOf(nameTranslations);
+    }
+
+    public String getSubjectDefaultLocale() {
+        return subjectDefaultLocale;
+    }
+
+    public void setSubjectDefaultLocale(String subjectDefaultLocale) {
+        this.subjectDefaultLocale = subjectDefaultLocale;
+    }
+
+    public Map<String, String> getSubjectTranslations() {
+        return subjectTranslations == null ? Map.of() : subjectTranslations;
+    }
+
+    public void setSubjectTranslations(Map<String, String> subjectTranslations) {
+        this.subjectTranslations = subjectTranslations == null ? Map.of() : Map.copyOf(subjectTranslations);
+    }
+
+    public String getContentDefaultLocale() {
+        return contentDefaultLocale;
+    }
+
+    public void setContentDefaultLocale(String contentDefaultLocale) {
+        this.contentDefaultLocale = contentDefaultLocale;
+    }
+
+    public Map<String, String> getContentTranslations() {
+        return contentTranslations == null ? Map.of() : contentTranslations;
+    }
+
+    public void setContentTranslations(Map<String, String> contentTranslations) {
+        this.contentTranslations = contentTranslations == null ? Map.of() : Map.copyOf(contentTranslations);
+    }
+
+    public String getDescriptionDefaultLocale() {
+        return descriptionDefaultLocale;
+    }
+
+    public void setDescriptionDefaultLocale(String descriptionDefaultLocale) {
+        this.descriptionDefaultLocale = descriptionDefaultLocale;
+    }
+
+    public Map<String, String> getDescriptionTranslations() {
+        return descriptionTranslations == null ? Map.of() : descriptionTranslations;
+    }
+
+    public void setDescriptionTranslations(Map<String, String> descriptionTranslations) {
+        this.descriptionTranslations = descriptionTranslations == null ? Map.of() : Map.copyOf(descriptionTranslations);
     }
 
     public OffsetDateTime getCreatedAt() {

--- a/backend/src/main/resources/db/migration/V6__template_i18n_fields.sql
+++ b/backend/src/main/resources/db/migration/V6__template_i18n_fields.sql
@@ -1,0 +1,9 @@
+ALTER TABLE mt_template_definition
+    ADD COLUMN IF NOT EXISTS name_default_locale VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS name_translations JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN IF NOT EXISTS subject_default_locale VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS subject_translations JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN IF NOT EXISTS content_default_locale VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS content_translations JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN IF NOT EXISTS description_default_locale VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS description_translations JSONB NOT NULL DEFAULT '{}'::JSONB;

--- a/backend/src/main/resources/mapper/TemplateMapper.xml
+++ b/backend/src/main/resources/mapper/TemplateMapper.xml
@@ -14,6 +14,18 @@
                 typeHandler="com.bob.mta.common.mybatis.StringListJsonTypeHandler"/>
         <result column="endpoint" property="endpoint"/>
         <result column="enabled" property="enabled"/>
+        <result column="name_default_locale" property="nameDefaultLocale"/>
+        <result column="name_translations" property="nameTranslations"
+                typeHandler="com.bob.mta.common.mybatis.StringMapJsonTypeHandler"/>
+        <result column="subject_default_locale" property="subjectDefaultLocale"/>
+        <result column="subject_translations" property="subjectTranslations"
+                typeHandler="com.bob.mta.common.mybatis.StringMapJsonTypeHandler"/>
+        <result column="content_default_locale" property="contentDefaultLocale"/>
+        <result column="content_translations" property="contentTranslations"
+                typeHandler="com.bob.mta.common.mybatis.StringMapJsonTypeHandler"/>
+        <result column="description_default_locale" property="descriptionDefaultLocale"/>
+        <result column="description_translations" property="descriptionTranslations"
+                typeHandler="com.bob.mta.common.mybatis.StringMapJsonTypeHandler"/>
         <result column="created_at" property="createdAt"/>
         <result column="updated_at" property="updatedAt"/>
     </resultMap>
@@ -26,6 +38,14 @@
                cc_recipients,
                endpoint,
                enabled,
+               name_default_locale,
+               name_translations,
+               subject_default_locale,
+               subject_translations,
+               content_default_locale,
+               content_translations,
+               description_default_locale,
+               description_translations,
                created_at,
                updated_at
         FROM mt_template_definition
@@ -44,6 +64,14 @@
                cc_recipients,
                endpoint,
                enabled,
+               name_default_locale,
+               name_translations,
+               subject_default_locale,
+               subject_translations,
+               content_default_locale,
+               content_translations,
+               description_default_locale,
+               description_translations,
                created_at,
                updated_at
         FROM mt_template_definition
@@ -58,6 +86,14 @@
             cc_recipients,
             endpoint,
             enabled,
+            name_default_locale,
+            name_translations,
+            subject_default_locale,
+            subject_translations,
+            content_default_locale,
+            content_translations,
+            description_default_locale,
+            description_translations,
             created_at,
             updated_at
         ) VALUES (
@@ -66,6 +102,14 @@
             #{ccRecipients, typeHandler=com.bob.mta.common.mybatis.StringListJsonTypeHandler},
             #{endpoint},
             #{enabled},
+            #{nameDefaultLocale},
+            #{nameTranslations, typeHandler=com.bob.mta.common.mybatis.StringMapJsonTypeHandler},
+            #{subjectDefaultLocale},
+            #{subjectTranslations, typeHandler=com.bob.mta.common.mybatis.StringMapJsonTypeHandler},
+            #{contentDefaultLocale},
+            #{contentTranslations, typeHandler=com.bob.mta.common.mybatis.StringMapJsonTypeHandler},
+            #{descriptionDefaultLocale},
+            #{descriptionTranslations, typeHandler=com.bob.mta.common.mybatis.StringMapJsonTypeHandler},
             #{createdAt},
             #{updatedAt}
         )
@@ -78,6 +122,14 @@
             cc_recipients = #{ccRecipients, typeHandler=com.bob.mta.common.mybatis.StringListJsonTypeHandler},
             endpoint = #{endpoint},
             enabled = #{enabled},
+            name_default_locale = #{nameDefaultLocale},
+            name_translations = #{nameTranslations, typeHandler=com.bob.mta.common.mybatis.StringMapJsonTypeHandler},
+            subject_default_locale = #{subjectDefaultLocale},
+            subject_translations = #{subjectTranslations, typeHandler=com.bob.mta.common.mybatis.StringMapJsonTypeHandler},
+            content_default_locale = #{contentDefaultLocale},
+            content_translations = #{contentTranslations, typeHandler=com.bob.mta.common.mybatis.StringMapJsonTypeHandler},
+            description_default_locale = #{descriptionDefaultLocale},
+            description_translations = #{descriptionTranslations, typeHandler=com.bob.mta.common.mybatis.StringMapJsonTypeHandler},
             updated_at = #{updatedAt}
         WHERE template_id = #{id}
     </update>

--- a/backend/src/test/java/com/bob/mta/modules/notification/HttpApiNotificationAdapterTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/notification/HttpApiNotificationAdapterTest.java
@@ -1,0 +1,55 @@
+package com.bob.mta.modules.notification;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.http.HttpStatus.ACCEPTED;
+
+class HttpApiNotificationAdapterTest {
+
+    @Test
+    void shouldInvokeRemoteEndpoint() {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpApiNotificationAdapter adapter = new HttpApiNotificationAdapter(restTemplate);
+
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        server.expect(requestTo("https://workflow.example.com"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-Correlation-Id", "123"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withStatus(ACCEPTED).body("{\"status\":\"ok\"}"));
+
+        ApiCallRequest request = new ApiCallRequest("https://workflow.example.com", "POST",
+                "{\"ticket\":42}", Map.of("X-Correlation-Id", "123"));
+        NotificationResult result = adapter.invoke(request);
+
+        server.verify();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getMetadata()).containsEntry("status", String.valueOf(ACCEPTED.value()));
+    }
+
+    @Test
+    void shouldReturnFailureWhenHttpError() {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpApiNotificationAdapter adapter = new HttpApiNotificationAdapter(restTemplate);
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        server.expect(requestTo("https://workflow.example.com"))
+                .andRespond(withServerError());
+
+        ApiCallRequest request = new ApiCallRequest("https://workflow.example.com", "POST", null, Map.of());
+        NotificationResult result = adapter.invoke(request);
+        assertThat(result.isSuccess()).isFalse();
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/notification/SmtpEmailNotificationAdapterTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/notification/SmtpEmailNotificationAdapterTest.java
@@ -1,0 +1,70 @@
+package com.bob.mta.modules.notification;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SmtpEmailNotificationAdapterTest {
+
+    @Test
+    void shouldSendEmailUsingJavaMailSender() throws Exception {
+        JavaMailSender mailSender = mock(JavaMailSender.class);
+        MimeMessage mimeMessage = new MimeMessage((Session) null);
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        doAnswer(invocation -> {
+            MimeMessage sent = invocation.getArgument(0);
+            sent.saveChanges();
+            return null;
+        }).when(mailSender).send(any(MimeMessage.class));
+
+        NotificationProperties properties = new NotificationProperties();
+        properties.getEmail().setEnabled(true);
+        properties.getEmail().setFrom("noreply@example.com");
+        properties.getEmail().setReplyTo("reply@example.com");
+
+        SmtpEmailNotificationAdapter adapter = new SmtpEmailNotificationAdapter(mailSender, properties);
+
+        EmailMessage request = new EmailMessage(List.of("user@example.com"), List.of("cc@example.com"),
+                "Subject", "<p>Hello</p>");
+        NotificationResult result = adapter.send(request);
+
+        verify(mailSender).send(captor.capture());
+        MimeMessage sent = captor.getValue();
+        List<String> recipients = Arrays.stream(sent.getAllRecipients())
+                .map(Object::toString)
+                .toList();
+        assertThat(recipients.toString()).contains("user@example.com");
+        assertThat(sent.getSubject()).isEqualTo("Subject");
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getMetadata()).containsEntry("from", "noreply@example.com");
+    }
+
+    @Test
+    void shouldReturnFailureWhenFromMissing() {
+        JavaMailSender mailSender = mock(JavaMailSender.class);
+        NotificationProperties properties = new NotificationProperties();
+        properties.getEmail().setEnabled(true);
+
+        SmtpEmailNotificationAdapter adapter = new SmtpEmailNotificationAdapter(mailSender, properties);
+
+        NotificationResult result = adapter.send(new EmailMessage(List.of("user@example.com"), List.of(),
+                "Subject", "Body"));
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getError()).contains("not configured");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/notification/WebhookInstantMessageNotificationAdapterTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/notification/WebhookInstantMessageNotificationAdapterTest.java
@@ -1,0 +1,59 @@
+package com.bob.mta.modules.notification;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class WebhookInstantMessageNotificationAdapterTest {
+
+    @Test
+    void shouldDispatchWebhookWithRecipients() {
+        RestTemplate restTemplate = new RestTemplate();
+        NotificationProperties properties = new NotificationProperties();
+        properties.getInstantMessage().setEnabled(true);
+        properties.getInstantMessage().setWebhookUrl("https://chat.example.com/webhook");
+
+        WebhookInstantMessageNotificationAdapter adapter =
+                new WebhookInstantMessageNotificationAdapter(restTemplate, properties);
+
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        server.expect(once(), requestTo("https://chat.example.com/webhook"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json("{" +
+                        "\"msgtype\":\"text\"," +
+                        "\"text\":{\"content\":\"hello\",\"mentioned_list\":[\"alice\"]}}"))
+                .andRespond(withSuccess());
+
+        NotificationResult result = adapter.send(new InstantMessage(List.of("alice"), "hello"));
+
+        server.verify();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getMetadata()).containsEntry("recipients", "alice");
+    }
+
+    @Test
+    void shouldFailWhenWebhookMissing() {
+        RestTemplate restTemplate = new RestTemplate();
+        NotificationProperties properties = new NotificationProperties();
+        properties.getInstantMessage().setEnabled(true);
+
+        WebhookInstantMessageNotificationAdapter adapter =
+                new WebhookInstantMessageNotificationAdapter(restTemplate, properties);
+
+        NotificationResult result = adapter.send(new InstantMessage(List.of(), "hello"));
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getError()).contains("not configured");
+    }
+}

--- a/backend/src/test/java/com/bob/mta/modules/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/template/controller/TemplateControllerTest.java
@@ -3,10 +3,8 @@ package com.bob.mta.modules.template.controller;
 import com.bob.mta.common.api.ApiResponse;
 import com.bob.mta.common.exception.BusinessException;
 import com.bob.mta.common.exception.ErrorCode;
-import com.bob.mta.common.i18n.InMemoryMultilingualTextRepository;
 import com.bob.mta.common.i18n.MultilingualTextPayload;
 import com.bob.mta.common.i18n.MessageResolver;
-import com.bob.mta.common.i18n.MultilingualTextService;
 import com.bob.mta.common.i18n.TestMessageResolverFactory;
 import com.bob.mta.modules.audit.service.AuditRecorder;
 import com.bob.mta.modules.audit.service.impl.InMemoryAuditService;
@@ -45,8 +43,7 @@ class TemplateControllerTest {
     @BeforeEach
     void setUp() {
         LocaleContextHolder.setLocale(Locale.SIMPLIFIED_CHINESE);
-        templateService = new TemplateServiceImpl(new InMemoryTemplateRepository(),
-                new MultilingualTextService(new InMemoryMultilingualTextRepository()));
+        templateService = new TemplateServiceImpl(new InMemoryTemplateRepository());
         localePreferenceService = new LocalePreferenceService(new LocaleSettingsRepository() {
             private String defaultLocale = Localization.getDefaultLocale().toLanguageTag();
 

--- a/backend/src/test/java/com/bob/mta/modules/template/repository/InMemoryTemplateRepository.java
+++ b/backend/src/test/java/com/bob/mta/modules/template/repository/InMemoryTemplateRepository.java
@@ -63,10 +63,25 @@ public class InMemoryTemplateRepository implements TemplateRepository {
                 : new ArrayList<>(source.getCcRecipients()));
         target.setEndpoint(source.getEndpoint());
         target.setEnabled(source.isEnabled());
+        target.setNameDefaultLocale(source.getNameDefaultLocale());
+        target.setNameTranslations(copyMap(source.getNameTranslations()));
+        target.setSubjectDefaultLocale(source.getSubjectDefaultLocale());
+        target.setSubjectTranslations(copyMap(source.getSubjectTranslations()));
+        target.setContentDefaultLocale(source.getContentDefaultLocale());
+        target.setContentTranslations(copyMap(source.getContentTranslations()));
+        target.setDescriptionDefaultLocale(source.getDescriptionDefaultLocale());
+        target.setDescriptionTranslations(copyMap(source.getDescriptionTranslations()));
         OffsetDateTime createdAt = source.getCreatedAt();
         OffsetDateTime updatedAt = source.getUpdatedAt();
         target.setCreatedAt(createdAt);
         target.setUpdatedAt(updatedAt);
         return target;
+    }
+
+    private Map<String, String> copyMap(Map<String, String> source) {
+        if (source == null || source.isEmpty()) {
+            return Map.of();
+        }
+        return Map.copyOf(source);
     }
 }

--- a/backend/src/test/java/com/bob/mta/modules/template/service/impl/TemplateServiceImplTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/template/service/impl/TemplateServiceImplTest.java
@@ -1,8 +1,6 @@
 package com.bob.mta.modules.template.service.impl;
 
-import com.bob.mta.common.i18n.InMemoryMultilingualTextRepository;
 import com.bob.mta.common.i18n.MultilingualText;
-import com.bob.mta.common.i18n.MultilingualTextService;
 import com.bob.mta.modules.template.domain.TemplateType;
 import com.bob.mta.modules.template.repository.InMemoryTemplateRepository;
 import org.junit.jupiter.api.Test;
@@ -15,8 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TemplateServiceImplTest {
 
-    private final TemplateServiceImpl service = new TemplateServiceImpl(new InMemoryTemplateRepository(),
-            new MultilingualTextService(new InMemoryMultilingualTextRepository()));
+    private final TemplateServiceImpl service = new TemplateServiceImpl(new InMemoryTemplateRepository());
 
     @Test
     void shouldRenderTemplate() {


### PR DESCRIPTION
## Summary
- persist template localization fields via new columns, migration, and mapper updates
- rework template service logic to read/write multilingual data and refresh supporting tests
- add configurable SMTP/email, webhook IM, and HTTP API notification adapters with fallback logging beans and properties binding

## Testing
- `mvn -q test` *(fails: cannot download spring-boot parent; Maven Central returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e5fbcd48832facbe90a4f86ebbd7