### PR TITLE
Refine JWT auth to use encoded credentials

### DIFF
--- a/backend/src/main/java/com/bob/mta/common/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/bob/mta/common/security/JwtTokenProvider.java
@@ -62,12 +62,17 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token);
             final Claims claims = jws.getBody();
             final Instant expiresAt = claims.getExpiration().toInstant();
+            final String issuer = claims.getIssuer();
+            final String expectedIssuer = properties.getIssuer();
+            if (expectedIssuer != null && !expectedIssuer.equals(issuer)) {
+                return Optional.empty();
+            }
             if (expiresAt.isBefore(Instant.now())) {
                 return Optional.empty();
             }
             final List<String> roles = extractRoles(claims);
             return Optional.of(new TokenPayload(
-                    claims.getIssuer(),
+                    issuer,
                     claims.get(CLAIM_USER_ID, String.class),
                     claims.getSubject(),
                     roles,

--- a/backend/src/test/java/com/bob/mta/common/security/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/JwtAuthenticationFilterTest.java
@@ -37,7 +37,7 @@ class JwtAuthenticationFilterTest {
     @Test
     @DisplayName("filter populates SecurityContext for valid bearer token")
     void shouldAuthenticateRequestWhenTokenPresent() throws ServletException, IOException {
-        final String token = tokenProvider.generateToken("1", "admin", "ADMIN");
+        final String token = tokenProvider.generateToken("1", "admin", java.util.List.of("ROLE_ADMIN")).token();
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
 

--- a/backend/src/test/java/com/bob/mta/common/security/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/bob/mta/common/security/JwtTokenProviderTest.java
@@ -2,6 +2,8 @@ package com.bob.mta.common.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,22 +26,25 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("token payload round trip succeeds for valid token")
     void shouldGenerateAndParseToken() {
-        final String token = tokenProvider.generateToken("1", "admin", "ADMIN");
+        final JwtTokenProvider.GeneratedToken token =
+                tokenProvider.generateToken("1", "admin", List.of("ROLE_ADMIN"));
 
-        final Optional<JwtTokenProvider.TokenPayload> payload = tokenProvider.parseToken(token);
+        final Optional<JwtTokenProvider.TokenPayload> payload = tokenProvider.parseToken(token.token());
 
         assertThat(payload).isPresent();
         assertThat(payload.get().username()).isEqualTo("admin");
-        assertThat(payload.get().role()).isEqualTo("ADMIN");
+        assertThat(payload.get().roles()).containsExactly("ROLE_ADMIN");
         assertThat(payload.get().issuer()).isEqualTo("bob-mta");
+        assertThat(payload.get().expiresAt()).isAfter(Instant.now());
     }
 
     @Test
     @DisplayName("parseToken returns empty for expired tokens")
     void shouldRejectExpiredTokens() {
         properties.getAccessToken().setExpirationMinutes(-1);
-        final String token = tokenProvider.generateToken("1", "admin", "ADMIN");
+        final JwtTokenProvider.GeneratedToken token =
+                tokenProvider.generateToken("1", "admin", List.of("ROLE_ADMIN"));
 
-        assertThat(tokenProvider.parseToken(token)).isEmpty();
+        assertThat(tokenProvider.parseToken(token.token())).isEmpty();
     }
 }


### PR DESCRIPTION
## Summary
- validate JWT issuers during parsing and reuse provider metadata when issuing tokens
- update the default auth service to rely on hashed credentials when producing login responses
- refresh authentication-related tests to assert JWT claims and BCrypt password handling

## Testing
- `mvn -q test` *(fails: cannot download parent POM from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e5f8abe4832f89e73e50c98bb2a1