### PR TITLE
Add error code coverage tests

### DIFF
--- a/backend/src/test/java/com/bob/mta/modules/customfield/service/impl/InMemoryCustomFieldServiceTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/customfield/service/impl/InMemoryCustomFieldServiceTest.java
@@ -43,4 +43,29 @@ class InMemoryCustomFieldServiceTest {
                 .extracting(ex -> ((BusinessException) ex).getErrorCode())
                 .isEqualTo(ErrorCode.CUSTOM_FIELD_NOT_FOUND);
     }
+
+    @Test
+    void shouldRejectDuplicateCode() {
+        service.createDefinition("env", "Environment", CustomFieldType.TEXT, false, null, null);
+
+        assertThatThrownBy(() -> service.createDefinition("env", "Environment", CustomFieldType.TEXT, false, null, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.VALIDATION_ERROR);
+    }
+
+    @Test
+    void shouldFailWhenRequiredFieldMissing() {
+        var requiredField = service.createDefinition("region", "Region", CustomFieldType.TEXT, true, null, null);
+
+        assertThatThrownBy(() -> service.updateValues("customer-42", Map.of()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.CUSTOM_FIELD_VALUE_INVALID);
+
+        assertThatThrownBy(() -> service.updateValues("customer-42", Map.of(requiredField.getId(), "   ")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.CUSTOM_FIELD_VALUE_INVALID);
+    }
 }

--- a/backend/src/test/java/com/bob/mta/modules/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/com/bob/mta/modules/template/controller/TemplateControllerTest.java
@@ -128,6 +128,18 @@ class TemplateControllerTest {
                 .isEqualTo(ErrorCode.TEMPLATE_NOT_FOUND);
     }
 
+    @Test
+    void shouldRejectRenderingDisabledTemplate() {
+        CreateTemplateRequest request = buildRequest();
+        request.setEnabled(false);
+        var created = controller.create(request, "ja-JP");
+
+        assertThatThrownBy(() -> controller.render(created.getData().getId(), null, "ja-JP"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.VALIDATION_ERROR);
+    }
+
     private CreateTemplateRequest buildRequest() {
         CreateTemplateRequest request = new CreateTemplateRequest();
         request.setType(TemplateType.EMAIL);


### PR DESCRIPTION
## Summary
- add regression coverage for validation scenarios in the in-memory custom field service
- cover disabled template rendering to assert validation error handling

## Testing
- `mvn test -Dtest=InMemoryCustomFieldServiceTest,TemplateControllerTest,TagControllerTest` *(fails: unable to download Spring Boot parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e5f8597c832fa23a11367522cda1